### PR TITLE
Save 1 byte of waste in uriToStringCharsRequired with URIs containing IPv4 addresses

### DIFF
--- a/src/UriRecompose.c
+++ b/src/UriRecompose.c
@@ -246,7 +246,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest,
 									}
 								}
 							} else {
-								(*charsRequired) += charsToWrite + 1;
+								(*charsRequired) += charsToWrite + ((i == 3) ? 0 : 1);
 							}
 						}
 					} else if (uri->hostData.ip6 != NULL) {


### PR DESCRIPTION
fix space requirements were 1 byte bigger than necessary when host is ipv4 address in uriToStringCharsRequired*