### PR TITLE
Fix Haiku build, link to -lsocket for inet_ntop

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,8 @@ AM_CONDITIONAL([WIN32], test "$WIN32" = "yes")
 AC_CHECK_FUNCS([wprintf])
 AC_CHECK_FUNCS([reallocarray])  # needs AC_USE_SYSTEM_EXTENSIONS (#define _GNU_SOURCE)
 
+## Haiku check for -lsocket -lnetwork inet_ntop
+AC_SEARCH_LIBS([inet_ntop],[socket network])
 
 ## Option --disable-test
 AC_ARG_ENABLE(test, [


### PR DESCRIPTION
Haiku fails the build when not linked against -lsocket/-lnetwork, this would reduce the need of creating a patch for Haiku and shouldn't affect other OS's