### PR TITLE
Fix VS2005 Build, UriMemory.c, UriMemory.h missing from project

### DIFF
--- a/win32/Visual_Studio_2005/uriparser.vcproj
+++ b/win32/Visual_Studio_2005/uriparser.vcproj
@@ -213,6 +213,14 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\src\UriMemory.c"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\UriMemory.h"
+				>
+			</File>
+			<File
 				RelativePath="..\..\src\UriNormalize.c"
 				>
 			</File>


### PR DESCRIPTION
Uriparser will compile w/o error, but the linker will throw unresolved external symbol errors when you go to actually use the library. 