### PR TITLE
Fix include of internal C header in C++ test

### DIFF
--- a/src/UriMemory.h
+++ b/src/UriMemory.h
@@ -37,6 +37,11 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef URI_MEMORY_H
+#define URI_MEMORY_H 1
+
+
+
 #ifndef URI_DOXYGEN
 # include <uriparser/Uri.h>
 #endif
@@ -57,3 +62,7 @@
 extern UriMemoryManager defaultMemoryManager;
 
 UriBool uriMemoryManagerIsComplete(const UriMemoryManager * memory);
+
+
+
+#endif /* URI_MEMORY_H */

--- a/test/MemoryManagerSuite.cpp
+++ b/test/MemoryManagerSuite.cpp
@@ -25,7 +25,11 @@
 #include <gtest/gtest.h>
 
 #include <uriparser/Uri.h>
+
+// For defaultMemoryManager
+extern "C" {
 #include "../src/UriMemory.h"
+}
 
 
 namespace {

--- a/test/MemoryManagerSuite.cpp
+++ b/test/MemoryManagerSuite.cpp
@@ -19,9 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <cassert>
-#include <cerrno>
-#include <cstring>  // memcpy
+#include <assert.h>
+#include <errno.h>
+#include <string.h>  // memcpy
 #include <gtest/gtest.h>
 
 #include <uriparser/Uri.h>


### PR DESCRIPTION
There are multiple ways to fix this:

  - Add (guarded) extern "C" to all internal include files in src
  - Declare just the variable we need in the C++ file instead of including the internal header
  - Add extern "C" around the include in the C++ file

I would probably go with the first, but I wasn't sure to which extent it might affect the double inclusion trickery. The second option duplicates the declaration, which is not good. So I went with option three, which doesn't change the existing code.

Btw, sorry about the two unrelated commits, it just seemed silly to open a separate PR for them (and they are at least header-related).
