### PR TITLE
cmake: Fix dll install path on Win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,9 @@ install(
     LIBRARY
         DESTINATION
             ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME
+        DESTINATION
+            ${CMAKE_INSTALL_BINDIR}
     PUBLIC_HEADER
         DESTINATION
             ${CMAKE_INSTALL_INCLUDEDIR}/uriparser


### PR DESCRIPTION
Currently, the shared lib build on Win32 doesn't work properly:
1. The generated DLL file exports no symbols, so a corresponding export lib will not be created. And the user of this lib has nothing to link to. This issue can be resolved by setting `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`: https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html
2. The generated DLL file installed to a wrong path. It is similar to: https://stackoverflow.com/questions/22278381/cmake-add-library-followed-by-install-library-destination