### PR TITLE
CMakeLists.txt: fix build without C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ cmake_minimum_required(VERSION 3.3)
 project(uriparser
     VERSION
         0.9.3
+    LANGUAGES
+        C
 )
 
 # See https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
@@ -242,6 +244,8 @@ endif()
 # C++ test runner
 #
 if(URIPARSER_BUILD_TESTS)
+    enable_language(CXX)
+
     enable_testing()
 
     find_package(GTest 1.8.1 REQUIRED)


### PR DESCRIPTION
Specify that uriparser is a C project (C++ is needed only for the test
runner) otherwise build will fail if no C++ compiler is found by cmake

Fixes:
 - http://autobuild.buildroot.org/results/1e191676f28905a81de6282e07978aa5d4f02039

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>