### PR TITLE
CMake: Use GTEST_INCLUDE_DIRS (plural) not GTEST_INCLUDE_DIR (singular) (for #79)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,7 @@ if(URIPARSER_BUILD_TESTS)
     endif()
 
     target_include_directories(testrunner SYSTEM PRIVATE
-        ${GTEST_INCLUDE_DIR}
+        ${GTEST_INCLUDE_DIRS}
     )
 
     target_include_directories(testrunner PRIVATE


### PR DESCRIPTION
For #79

CC @wouterbeek