### PR TITLE
cmake: fix static lib name for MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,10 @@ if(NOT MSVC)
     set_property(TARGET uriparser PROPERTY VERSION ${URIPARSER_SO_CURRENT_MINUS_AGE}.${URIPARSER_SO_AGE}.${URIPARSER_SO_REVISION})
     set_property(TARGET uriparser PROPERTY SOVERSION ${URIPARSER_SO_CURRENT_MINUS_AGE})
     if(WIN32)
-        set_property(TARGET uriparser PROPERTY SUFFIX "-${URIPARSER_SO_CURRENT_MINUS_AGE}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+        set_target_properties(uriparser PROPERTIES
+            OUTPUT_NAME uriparser
+            RUNTIME_OUTPUT_NAME uriparser-${URIPARSER_SO_CURRENT_MINUS_AGE}
+            ARCHIVE_OUTPUT_NAME uriparser)
     endif()
 endif()
 


### PR DESCRIPTION
https://github.com/uriparser/uriparser/pull/64 changed not only dll name but also name of static lib, which lead to wrong extension.
This PR fixes extension for static lib with MinGW, while keeping version suffix in dll name.