### PR TITLE
Update Intel Compiler Defs

### DIFF
--- a/include/uriparser/UriDefsConfig.h
+++ b/include/uriparser/UriDefsConfig.h
@@ -82,7 +82,8 @@
 /* Intel C/C++ */
 /* http://predef.sourceforge.net/precomp.html#sec20 */
 /* http://www.intel.com/support/performancetools/c/windows/sb/CS-007751.htm#2 */
-# define URI_INLINE __force_inline
+/* EDIT 11/5/20. Intel changed __force_inline to __forceinline */
+# define URI_INLINE __forceinline
 #elif defined(_MSC_VER)
 /* Microsoft Visual C++ */
 /* http://predef.sourceforge.net/precomp.html#sec32 */

--- a/include/uriparser/UriDefsConfig.h
+++ b/include/uriparser/UriDefsConfig.h
@@ -82,7 +82,6 @@
 /* Intel C/C++ */
 /* http://predef.sourceforge.net/precomp.html#sec20 */
 /* http://www.intel.com/support/performancetools/c/windows/sb/CS-007751.htm#2 */
-/* EDIT 11/5/20. Intel changed __force_inline to __forceinline */
 # define URI_INLINE __forceinline
 #elif defined(_MSC_VER)
 /* Microsoft Visual C++ */


### PR DESCRIPTION
At some point, Intel changed __force_inline to __forceinline. Source: [here](https://software.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/compiler-options/compiler-option-details/inlining-options/inline-forceinline-qinline-forceinline.html)