### PR TITLE
CMakeLists.txt: Link against pthreads for -DURIPARSER_BUILD_TESTS=ON (fixes #99)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,10 @@ if(URIPARSER_BUILD_TESTS)
         ${GTEST_BOTH_LIBRARIES}
     )
 
+    # NOTE: uriparser does not use pthreads itself but gtest does
+    find_package(Threads REQUIRED)
+    target_link_libraries(testrunner PRIVATE Threads::Threads)
+
     add_test(
         NAME
             test

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,8 @@ NOTE: uriparser is looking for help with a few things:
   * Fixed: Use correct inline marker "__forceinline" for Intel C++ Compiler
       (GitHub #93)
       Thanks to jensenrichardson for the patch!
+  * Fixed: Link against pthreads for (default) -DURIPARSER_BUILD_TESTS=ON
+      (GitHub #99)
   * Improved: pkg-config: Use ${prefix} and ${exec_prefix} to ease
       overriding variables using --define-variable=NAME=VALUE,
       e.g. as done on OpenWRT (GitHub #91)


### PR DESCRIPTION
Fixes #99