### PR TITLE
Migrate CI to Qt 5

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Add Clang/LLVM repositories
         run: |-
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main'
+          sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
 
       - name: Install build dependencies
         run: |-

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
               graphviz \
               llvm-11 \
               lzip \
-              qt4-dev-tools \
+              qhelpgenerator-qt5 \
               qtchooser
 
       - name: Build, test and install


### PR DESCRIPTION
In reaction to https://github.com/uriparser/uriparser/runs/2092156827?check_suite_focus=true caused by `ubuntu-latest` jumping from bionic/18.04.x to focal/20.04.x…