### PR TITLE
CMake: Support absolute paths for CMAKE_INSTALL_(LIB|INCLUDE)DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,18 @@ uriparser_install(
 # pkg-config file
 #
 if(NOT MSVC)
+    if(CMAKE_INSTALL_LIBDIR MATCHES "^/")
+        set(_URIPARSER_PKGCONFIG_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+    else()
+        set(_URIPARSER_PKGCONFIG_LIBDIR "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+    endif()
+
+    if(CMAKE_INSTALL_INCLUDEDIR MATCHES "^/")
+        set(_URIPARSER_PKGCONFIG_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+    else()
+        set(_URIPARSER_PKGCONFIG_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+    endif()
+
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/liburiparser.pc.in liburiparser.pc @ONLY)
     uriparser_install(
         FILES

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,9 @@ XXXX-XX-XX -- X.X.X
   * Fixed: CMake: Call "enable_language(CXX)" prior to tinkering with
       CMAKE_CXX_* variables (GitHub #110)
       Thanks to Alexander Richardson for the patch (originally at libexpat)
+  * Fixed: CMake: Support absolute paths for both CMAKE_INSTALL_LIBDIR
+      and CMAKE_INSTALL_INCLUDEDIR (GitHub #114)
+      Thanks to Rafael Fontenelle for bringing this up (originally at libexpat)
   * Fixed: Windows: Address MSVC compiler warnings (GitHub #111)
   * Fixed: Addressed MSVC compiler warnings in test suite code (GitHub #113)
 

--- a/THANKS
+++ b/THANKS
@@ -45,6 +45,7 @@ myd7349
 Periklis Akritidis
 Philip de Nier
 Radu Hociung
+Rafael Fontenelle
 Ralf S. Engelschall
 Rakesh Pandit
 René Rebe

--- a/liburiparser.pc.in
+++ b/liburiparser.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@_URIPARSER_PKGCONFIG_LIBDIR@
+includedir=@_URIPARSER_PKGCONFIG_INCLUDEDIR@
 
 Name: liburiparser
 Description: URI parsing and handling library


### PR DESCRIPTION
Related to https://github.com/libexpat/libexpat/pull/459

CC @rffontenelle