### PR TITLE
Doc: Fix space requirements of uriUriStringToUnixFilename (fixes #118)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,10 @@ XXXX-XX-XX -- X.X.X
       and CMAKE_INSTALL_INCLUDEDIR (GitHub #114)
       Thanks to Rafael Fontenelle for bringing this up (originally at libexpat)
   * Fixed: Windows: Address MSVC compiler warnings (GitHub #111, GitHub #113)
+  * Fixed: Documentation: Space requirements for uriUriStringToUnixFilename
+      did not take into account short form "file:/bin/bash" of RFC 8089 of 2017
+      (with prefix "file:/" rather than "file:///") that uriparser supports
+      since release 0.8.6 in 2018 (GitHub #118, GitHub #119)
   * Improved: Respect variable ${CPP} in doc/preprocess.sh (GitHub #115)
 
 2021-03-18 -- 0.9.5

--- a/include/uriparser/Uri.h
+++ b/include/uriparser/Uri.h
@@ -769,7 +769,7 @@ URI_PUBLIC int URI_FUNC(WindowsFilenameToUriString)(const URI_CHAR * filename,
 
 /**
  * Extracts a Unix filename from a %URI string.
- * The destination buffer must be large enough to hold len(uriString) + 1 - 7
+ * The destination buffer must be large enough to hold len(uriString) + 1 - 5
  * characters in case of an absolute %URI or len(uriString) + 1 in case
  * of a relative %URI.
  *


### PR DESCRIPTION
Fixes #118

CC @b-carr