### PR TITLE
uriparse: use size_t for inet_ntop declaration and fix macro checks for MinGW and mingw-w64

### DIFF
--- a/tool/uriparse.c
+++ b/tool/uriparse.c
@@ -43,9 +43,11 @@
 #ifdef _WIN32
 # include <winsock2.h>
 # include <ws2tcpip.h>
-# ifdef __MINGW32__
+# if defined(__MINGW32__) &&                                              \
+     (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 3 || \
+      _WIN32_WINNT < _WIN32_WINNT_VISTA)
 WINSOCK_API_LINKAGE const char * WSAAPI inet_ntop(
-		int af, const void *src, char *dst, socklen_t size);
+		int af, const void *src, char *dst, size_t size);
 # endif
 #else
 # include <sys/socket.h>


### PR DESCRIPTION
From a patch from msys2, `/usr/x86_64-w64-mingw32/include/_mingw.h` defines `_WIN32_WINNT` on mingw-w64 cross compilers