### PR TITLE
Fix implicit declaration warning for reallocarray on NetBSD

### DIFF
--- a/src/UriMemory.c
+++ b/src/UriMemory.c
@@ -48,6 +48,9 @@
 # ifndef _GNU_SOURCE
 #  define _GNU_SOURCE 1
 # endif
+# ifdef __NetBSD__
+#  define _OPENBSD_SOURCE 1
+# endif
 #endif
 
 #include <errno.h>


### PR DESCRIPTION
Fix implicit declaration warning of function reallocarray on NetBSD.