### PR TITLE
Fix tool/uriparse.c for MinGW-w64

### DIFF
--- a/tool/uriparse.c
+++ b/tool/uriparse.c
@@ -43,7 +43,7 @@
 #ifdef _WIN32
 # include <winsock2.h>
 # include <ws2tcpip.h>
-# ifdef __MINGW32__
+# if defined(__MINGW32__) && !defined(InetNtopA)
 WINSOCK_API_LINKAGE const char * WSAAPI inet_ntop(
 		int af, const void *src, char *dst, socklen_t size);
 # endif


### PR DESCRIPTION
Fix `tool/uriparse.c` for MinGW-w64 where `inet_ntop` is already defined.