### PR TITLE
Fix missing include config.h

### DIFF
--- a/src/UriMemory.c
+++ b/src/UriMemory.c
@@ -42,8 +42,6 @@
  * Holds memory manager implementation.
  */
 
-#include <config.h>
-
 #ifdef HAVE_REALLOCARRAY
 # ifndef _GNU_SOURCE
 #  define _GNU_SOURCE 1


### PR DESCRIPTION
Fixes issue: https://github.com/uriparser/uriparser/issues/134

With missing config.h
Advise if another issues otherwise

This complies successfully 