### PR TITLE
CMake: Add option to expose (otherwise hidden) symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ option(URIPARSER_BUILD_TESTS "Build test suite (requires GTest >=1.8.0)" ON)
 option(URIPARSER_BUILD_TOOLS "Build tools (e.g. CLI \"uriparse\")" ON)
 option(URIPARSER_BUILD_CHAR "Build code supporting data type 'char'" ON)
 option(URIPARSER_BUILD_WCHAR_T "Build code supporting data type 'wchar_t'" ON)
+option(URIPARSER_VISIBILITY_HIDDEN "Build libraries with hidden symbols unless they are specifically exported" ON)
 option(URIPARSER_ENABLE_INSTALL "Enable installation of uriparser" ON)
 option(URIPARSER_WARNINGS_AS_ERRORS "Treat all compiler warnings as errors" OFF)
 set(URIPARSER_MSVC_RUNTIME "" CACHE STRING "Use of specific runtime library (/MT /MTd /MD /MDd) with MSVC")
@@ -104,9 +105,11 @@ endmacro()
 #
 set(URIPARSER_EXTRA_COMPILE_FLAGS)
 
+if(URIPARSER_VISIBILITY_HIDDEN)
 check_c_compiler_flag("-fvisibility=hidden" URIPARSER_COMPILER_SUPPORTS_VISIBILITY)
 if(URIPARSER_COMPILER_SUPPORTS_VISIBILITY)
     set(URIPARSER_EXTRA_COMPILE_FLAGS "${URIPARSER_EXTRA_COMPILE_FLAGS} -fvisibility=hidden")
+endif()
 endif()
 
 #

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ URIPARSER_ENABLE_INSTALL:BOOL=ON
 // Use of specific runtime library (/MT /MTd /MD /MDd) with MSVC
 URIPARSER_MSVC_RUNTIME:STRING=
 
+// Build libraries with hidden symbols unless they are specifically exported
+URIPARSER_VISIBILITY_HIDDEN:BOOL=ON
+
 // Treat all compiler warnings as errors
 URIPARSER_WARNINGS_AS_ERRORS:BOOL=OFF
 ```


### PR DESCRIPTION
We would like to propose a new option to CMake, which allows exposing functions to the linker.

Some project like https://github.com/google/sandboxed-api requires this to build a sandbox.

By default, the option will still be disabled, but it would be good to allow the user to change this setting.