### PR TITLE
Include config.h only when it has not already been defined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.idea/
-/config.h
+/UriConfig.h
 /build/
 /cmake-build-debug/
 /CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,11 +110,11 @@ if(URIPARSER_COMPILER_SUPPORTS_VISIBILITY)
 endif()
 
 #
-# config.h
+# UriConfig.h
 #
 check_symbol_exists(wprintf wchar.h HAVE_WPRINTF)
 check_function_exists(reallocarray HAVE_REALLOCARRAY)  # no luck with CheckSymbolExists
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/UriConfig.h.in config.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/UriConfig.h.in UriConfig.h)
 
 #
 # C library
@@ -193,7 +193,7 @@ target_include_directories(uriparser
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     PRIVATE
-        ${CMAKE_CURRENT_BINARY_DIR}  # for config.h
+        ${CMAKE_CURRENT_BINARY_DIR}  # for UriConfig.h
 )
 
 uriparser_install(
@@ -288,7 +288,7 @@ if(URIPARSER_BUILD_TESTS)
 
     target_include_directories(testrunner PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
-        ${CMAKE_CURRENT_BINARY_DIR}  # for config.h
+        ${CMAKE_CURRENT_BINARY_DIR}  # for UriConfig.h
     )
 
     target_link_libraries(testrunner PUBLIC

--- a/src/UriMemory.c
+++ b/src/UriMemory.c
@@ -42,9 +42,7 @@
  * Holds memory manager implementation.
  */
 
-#ifndef URI_CONFIG_H
-#include <config.h>  /* for HAVE_REALLOCARRAY */
-#endif
+#include "UriConfig.h"  /* for HAVE_REALLOCARRAY */
 
 #ifdef HAVE_REALLOCARRAY
 # ifndef _GNU_SOURCE

--- a/src/UriMemory.c
+++ b/src/UriMemory.c
@@ -42,7 +42,9 @@
  * Holds memory manager implementation.
  */
 
+#ifndef URI_CONFIG_H
 #include <config.h>  /* for HAVE_REALLOCARRAY */
+#endif
 
 #ifdef HAVE_REALLOCARRAY
 # ifndef _GNU_SOURCE

--- a/test/VersionSuite.cpp
+++ b/test/VersionSuite.cpp
@@ -23,7 +23,7 @@
 #include <cstdio>
 
 
-#include <config.h>  // for PACKAGE_VERSION
+#include "UriConfig.h"  // for PACKAGE_VERSION
 #include <uriparser/UriBase.h>
 
 


### PR DESCRIPTION
This guard makes it possible to build the entire project without a config.h file, instead all the preprocessor definitions can be provided from the command line.

In my case, we build the entire library by including all `.c` files in a single `.c` file with all the needed definitions, thus simplifying the build process:

in `liburiparser.c`
```
#define URI_CONFIG_H 1
#define PACKAGE_VERSION "0.9.6"
#define HAVE_WPRINTF
#include "uriparser/src/UriCommon.c"
#include "uriparser/src/UriCompare.c"
#include "uriparser/src/UriEscape.c"
#include "uriparser/src/UriFile.c"
#include "uriparser/src/UriIp4.c"
#include "uriparser/src/UriIp4Base.c"
#include "uriparser/src/UriMemory.c"
#include "uriparser/src/UriNormalize.c"
#include "uriparser/src/UriNormalizeBase.c"
#include "uriparser/src/UriParse.c"
#include "uriparser/src/UriParseBase.c"
#include "uriparser/src/UriQuery.c"
#include "uriparser/src/UriRecompose.c"
#include "uriparser/src/UriResolve.c"
#include "uriparser/src/UriShorten.c"
```
