### PR TITLE
Fix IPv6 and IPvFuture literal parsing

### DIFF
--- a/src/UriParse.c
+++ b/src/UriParse.c
@@ -782,7 +782,7 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(
 								return NULL; /* ":::+ "*/
 							}
 						} else if (quadsDone == 0 || first[1] == _UT(']')) {
-							/* Leading or trailing ":" */
+							/* Single leading or trailing ":" */
 							URI_FUNC(StopSyntax)(state, first, memory);
 							return NULL;
 						}
@@ -794,8 +794,7 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(
 					break;
 
 				case _UT('.'):
-					if ((quadsDone > 6) /* NOTE */
-							|| (zipperEver && (quadsDone == 6))
+					if ((quadsDone + zipperEver > 6) /* NOTE */
 							|| (!zipperEver && (quadsDone < 6))
 							|| letterAmong
 							|| (digitCount == 0)
@@ -841,8 +840,8 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(
 
 					if (digitCount > 0) {
 						if (zipperEver) {
-							/* Zipping no quads? */
-							if (quadsDone == 7) {
+							/* Too many quads? */
+							if (quadsDone >= 7) {
 								URI_FUNC(StopSyntax)(state, first, memory);
 								return NULL;
 							}

--- a/src/UriParse.c
+++ b/src/UriParse.c
@@ -795,6 +795,7 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(
 
 				case _UT('.'):
 					if ((quadsDone > 6) /* NOTE */
+							|| (zipperEver && (quadsDone == 6))
 							|| (!zipperEver && (quadsDone < 6))
 							|| letterAmong
 							|| (digitCount == 0)

--- a/src/UriParse.c
+++ b/src/UriParse.c
@@ -478,6 +478,7 @@ static const URI_CHAR * URI_FUNC(ParseIpFuture)(URI_TYPE(ParserState) * state,
 
 	switch (*first) {
 	case _UT('v'):
+	case _UT('V'):
 	*/
 		if (first + 1 >= afterLast) {
 			URI_FUNC(StopSyntax)(state, afterLast, memory);
@@ -540,7 +541,9 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseIpLit2)(
 	}
 
 	switch (*first) {
+	/* The leading "v" of IPvFuture is case-insensitive. */
 	case _UT('v'):
+	case _UT('V'):
 		{
 			const URI_CHAR * const afterIpFuture
 					= URI_FUNC(ParseIpFuture)(state, first, afterLast, memory);
@@ -624,11 +627,6 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(
 						/* Leading zero */
 						URI_FUNC(StopSyntax)(state, first - digitCount, memory);
 						return NULL;
-					} else if ((digitCount > 2)
-							&& (digitHistory[1] == 0)) {
-						/* Leading zero */
-						URI_FUNC(StopSyntax)(state, first - digitCount + 1, memory);
-						return NULL;
 					} else if ((digitCount == 3)
 							&& (100 * digitHistory[0]
 								+ 10 * digitHistory[1]
@@ -661,11 +659,6 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(
 							&& (digitHistory[0] == 0)) {
 						/* Leading zero */
 						URI_FUNC(StopSyntax)(state, first - digitCount, memory);
-						return NULL;
-					} else if ((digitCount > 2)
-							&& (digitHistory[1] == 0)) {
-						/* Leading zero */
-						URI_FUNC(StopSyntax)(state, first - digitCount + 1, memory);
 						return NULL;
 					} else if ((digitCount == 3)
 							&& (100 * digitHistory[0]
@@ -788,6 +781,10 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(
 								URI_FUNC(StopSyntax)(state, first + 1, memory);
 								return NULL; /* ":::+ "*/
 							}
+						} else if (quadsDone == 0 || first[1] == _UT(']')) {
+							/* Leading or trailing ":" */
+							URI_FUNC(StopSyntax)(state, first, memory);
+							return NULL;
 						}
 
 						if (setZipper) {
@@ -809,11 +806,6 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(
 							&& (digitHistory[0] == 0)) {
 						/* Leading zero */
 						URI_FUNC(StopSyntax)(state, first - digitCount, memory);
-						return NULL;
-					} else if ((digitCount > 2)
-							&& (digitHistory[1] == 0)) {
-						/* Leading zero */
-						URI_FUNC(StopSyntax)(state, first - digitCount + 1, memory);
 						return NULL;
 					} else if ((digitCount == 3)
 							&& (100 * digitHistory[0]
@@ -848,6 +840,11 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(
 
 					if (digitCount > 0) {
 						if (zipperEver) {
+							/* Zipping no quads? */
+							if (quadsDone == 7) {
+								URI_FUNC(StopSyntax)(state, first, memory);
+								return NULL;
+							}
 							uriWriteQuadToDoubleByte(digitHistory, digitCount, quadsAfterZipper + 2 * quadsAfterZipperCount);
 							quadsAfterZipperCount++;
 						} else {

--- a/test/FourSuite.cpp
+++ b/test/FourSuite.cpp
@@ -511,6 +511,10 @@ TEST(FourSuite, GoodUriReferences) {
 	// Random other things that crop up
 	ASSERT_TRUE(testGoodUri("http://example/Andr&#567;"));
 	ASSERT_TRUE(testGoodUri("file:///C:/DEV/Haskell/lib/HXmlToolbox-3.01/examples/"));
+
+	// Issue #146: The leading "v" of IPvFuture is case-insensitive.
+	ASSERT_TRUE(testGoodUri("//[vF.addr]"));
+	ASSERT_TRUE(testGoodUri("//[VF.addr]"));
 }
 
 

--- a/test/FourSuite.cpp
+++ b/test/FourSuite.cpp
@@ -511,10 +511,6 @@ TEST(FourSuite, GoodUriReferences) {
 	// Random other things that crop up
 	ASSERT_TRUE(testGoodUri("http://example/Andr&#567;"));
 	ASSERT_TRUE(testGoodUri("file:///C:/DEV/Haskell/lib/HXmlToolbox-3.01/examples/"));
-
-	// Issue #146: The leading "v" of IPvFuture is case-insensitive.
-	ASSERT_TRUE(testGoodUri("//[vF.addr]"));
-	ASSERT_TRUE(testGoodUri("//[VF.addr]"));
 }
 
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -282,6 +282,9 @@ TEST(UriSuite, TestIpSixFail) {
 		URI_TEST_IP_SIX_FAIL(":0:0:0:0:0:0:0:0");
 		URI_TEST_IP_SIX_FAIL("0:0:0:0:0:0:0:0:");
 		URI_TEST_IP_SIX_FAIL(":0:0:0:0:0:0:0:0:");
+
+		// Issue #146: Zipper between six quads and IPv4 address.
+		URI_TEST_IP_SIX_FAIL("1:1:1:1:1:1::1.1.1.1");
 }
 
 TEST(UriSuite, TestIpSixOverread) {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -287,6 +287,18 @@ TEST(UriSuite, TestIpSixFail) {
 		URI_TEST_IP_SIX_FAIL("1:1:1:1:1:1::1.1.1.1");
 }
 
+TEST(UriSuite, TestIpFuture) {
+		UriParserStateA stateA;
+		UriUriA uriA;
+		stateA.uri = &uriA;
+
+		// Issue #146: The leading "v" of IPvFuture is case-insensitive.
+		ASSERT_TRUE(0 == uriParseUriA(&stateA, "//[vF.addr]"));
+		uriFreeUriMembersA(&uriA);
+		ASSERT_TRUE(0 == uriParseUriA(&stateA, "//[VF.addr]"));
+		uriFreeUriMembersA(&uriA);
+}
+
 TEST(UriSuite, TestIpSixOverread) {
 		UriUriA uri;
 		const char * errorPos;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -213,6 +213,18 @@ TEST(UriSuite, TestIpSixPass) {
 		URI_TEST_IP_SIX_PASS("2001:db8:100:f101::1");
 		URI_TEST_IP_SIX_PASS("a:b:c::12:1");
 		URI_TEST_IP_SIX_PASS("a:b::0:1:2:3");
+
+		// Issue #146: These are not leading zeros.
+		URI_TEST_IP_SIX_PASS("::100.1.1.1");
+		URI_TEST_IP_SIX_PASS("::1.100.1.1");
+		URI_TEST_IP_SIX_PASS("::1.1.100.1");
+		URI_TEST_IP_SIX_PASS("::1.1.1.100");
+		URI_TEST_IP_SIX_PASS("::100.100.100.100");
+		URI_TEST_IP_SIX_PASS("::10.1.1.1");
+		URI_TEST_IP_SIX_PASS("::1.10.1.1");
+		URI_TEST_IP_SIX_PASS("::1.1.10.1");
+		URI_TEST_IP_SIX_PASS("::1.1.1.10");
+		URI_TEST_IP_SIX_PASS("::10.10.10.10");
 }
 
 TEST(UriSuite, TestIpSixFail) {
@@ -259,6 +271,17 @@ TEST(UriSuite, TestIpSixFail) {
 
 		// Nonhex
 		URI_TEST_IP_SIX_FAIL("g:0:0:0:0:0:0");
+
+		// Issue #146: Zipper between the 7th and 8th quads.
+		URI_TEST_IP_SIX_FAIL("0:0:0:0:0:0:0::1");
+
+		// Issue #146: Leading or trailing ":".
+		URI_TEST_IP_SIX_FAIL(":1::1");
+		URI_TEST_IP_SIX_FAIL("1::1:");
+		URI_TEST_IP_SIX_FAIL(":1::1:");
+		URI_TEST_IP_SIX_FAIL(":0:0:0:0:0:0:0:0");
+		URI_TEST_IP_SIX_FAIL("0:0:0:0:0:0:0:0:");
+		URI_TEST_IP_SIX_FAIL(":0:0:0:0:0:0:0:0:");
 }
 
 TEST(UriSuite, TestIpSixOverread) {


### PR DESCRIPTION
Closes #146. This is ready for review now. @hartwork

I've added several test cases for the issue and can confirm that all the five bugs listed in #146 are fixed.