### PR TITLE
Actions: Make sure that AddressSanitizer files are always available

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,7 +87,7 @@ jobs:
         run: |-
           sudo apt-get install --yes --no-install-recommends -V \
               clang-15 \
-              llvm-15
+              libclang-rt-15-dev
 
       - name: Build, test and install
         run: |-


### PR DESCRIPTION
Symptom was:
> /usr/bin/ld: cannot find /usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.asan_static-x86_64.a: No such file or directory
> /usr/bin/ld: cannot find /usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.asan-x86_64.a: No such file or directory

Related:
https://github.com/llvm/llvm-project/issues/60008