### PR TITLE
CMake: Introduce option `URIPARSER_SHARED_LIBS=(ON|OFF)` (fixes #169)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,12 @@ include(GNUInstallDirs)
 #
 # Configuration
 #
-option(BUILD_SHARED_LIBS "Build shared libraries (rather than static ones)" ON)
+if(DEFINED BUILD_SHARED_LIBS)
+    set(_URIPARSER_SHARED_LIBS_DEFAULT ${BUILD_SHARED_LIBS})
+else()
+    set(_URIPARSER_SHARED_LIBS_DEFAULT ON)
+endif()
+option(URIPARSER_SHARED_LIBS "Build shared libraries (rather than static ones)" ${_URIPARSER_SHARED_LIBS_DEFAULT})
 option(URIPARSER_BUILD_DOCS "Build API documentation (requires Doxygen, Graphviz, and (optional) Qt's qhelpgenerator)" ON)
 option(URIPARSER_BUILD_TESTS "Build test suite (requires GTest >=1.8.0)" ON)
 option(URIPARSER_BUILD_TOOLS "Build tools (e.g. CLI \"uriparse\")" ON)
@@ -81,6 +86,12 @@ endif()
 if(URIPARSER_BUILD_TESTS)
     # We have to call enable_language() before modifying any CMAKE_CXX_* variables
     enable_language(CXX)
+endif()
+
+if(URIPARSER_SHARED_LIBS)
+    set(_URIPARSER_STATIC_OR_SHARED SHARED)
+else()
+    set(_URIPARSER_STATIC_OR_SHARED STATIC)
 endif()
 
 macro(uriparser_apply_msvc_runtime_to ref)
@@ -151,6 +162,7 @@ set(LIBRARY_CODE_FILES
 )
 
 add_library(uriparser
+    ${_URIPARSER_STATIC_OR_SHARED}
     ${API_HEADER_FILES}
     ${LIBRARY_CODE_FILES}
 )
@@ -175,7 +187,7 @@ set_property(
 )
 
 target_compile_definitions(uriparser PRIVATE URI_LIBRARY_BUILD)
-if (NOT BUILD_SHARED_LIBS)
+if (NOT URIPARSER_SHARED_LIBS)
     target_compile_definitions(uriparser PUBLIC URI_STATIC_BUILD)
 endif()
 if(NOT URIPARSER_BUILD_CHAR)
@@ -464,7 +476,7 @@ message(STATUS "================================================================
 message(STATUS "")
 message(STATUS "Configuration")
 message(STATUS "  Build type ............. ${CMAKE_BUILD_TYPE}")
-message(STATUS "  Shared libraries ....... ${BUILD_SHARED_LIBS}")
+message(STATUS "  Shared libraries ....... ${URIPARSER_SHARED_LIBS}")
 message(STATUS "  Compiler flags")
 message(STATUS "    C .................... ${CMAKE_C_FLAGS}")
 message(STATUS "    C++ .................. ${CMAKE_CXX_FLAGS}")

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,13 @@ NOTE: uriparser is looking for help with a few things:
       https://github.com/uriparser/uriparser/labels/help%20wanted
       If you can help, please get in touch.  Thanks!
 
+xxxx-xx-xx -- x.x.x
+
+  * Added: CMake option URIPARSER_SHARED_LIBS=(ON|OFF) to control,
+      whether to produce a shared or static library for uriparser
+      and that alone, falls back to standard BUILD_SHARED_LIBS
+      if available, else defaults to "ON" (GitHub #169, GitHub #170)
+
 2022-10-05 -- 0.9.7
 
   * Fixed: Multiple issues with IPv6 and IPvFuture literal parsing

--- a/README.md
+++ b/README.md
@@ -49,9 +49,6 @@ target_link_libraries(hello PUBLIC uriparser::uriparser)
 ## Available CMake options (and defaults)
 ```console
 # rm -f CMakeCache.txt ; cmake -LH . | grep -B1 ':.*=' | sed 's,--,,'
-// Build shared libraries (rather than static ones)
-BUILD_SHARED_LIBS:BOOL=ON
-
 // Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel ...
 CMAKE_BUILD_TYPE:STRING=
 
@@ -81,6 +78,9 @@ URIPARSER_ENABLE_INSTALL:BOOL=ON
 
 // Use of specific runtime library (/MT /MTd /MD /MDd) with MSVC
 URIPARSER_MSVC_RUNTIME:STRING=
+
+// Build shared libraries (rather than static ones)
+URIPARSER_SHARED_LIBS:BOOL=ON
 
 // Treat all compiler warnings as errors
 URIPARSER_WARNINGS_AS_ERRORS:BOOL=OFF


### PR DESCRIPTION
.. that mimics flag `BUILD_SHARED_LIBS` and falls back to `BUILD_SHARED_LIBS` if available, else defaults to `ON`.

Related:
https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html

Fixes #169