### PR TITLE
Require CMake >=3.5.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -104,7 +104,7 @@ jobs:
             cd googletest-release-${GTEST_VERSION}/
 
             # Silence warning "Compatibility with CMake < 2.8.12 will be removed"
-            find -name CMakeLists.txt -print -exec sed 's/cmake_minimum_required.*/cmake_minimum_required(VERSION 3.0.2)/' -i {} \;
+            find -name CMakeLists.txt -print -exec sed 's/cmake_minimum_required.*/cmake_minimum_required(VERSION 3.5.0)/' -i {} \;
 
             cmake \
                 -DBUILD_SHARED_LIBS=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(uriparser
     VERSION

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ NOTE: uriparser is looking for help with a few things:
 
 xxxx-xx-xx -- x.x.x
 
+  * Changed: Require CMake >=3.5.0 (GitHub #172)
   * Added: CMake option URIPARSER_SHARED_LIBS=(ON|OFF) to control,
       whether to produce a shared or static library for uriparser
       and that alone, falls back to standard BUILD_SHARED_LIBS

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ please check out [https://uriparser.github.io/](https://uriparser.github.io/).
 # Example use from an existing CMake project
 
 ```cmake
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(hello VERSION 1.0.0)
 

--- a/cmake/test_find_package/CMakeLists.txt
+++ b/cmake/test_find_package/CMakeLists.txt
@@ -34,7 +34,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(test-find-package VERSION 1.0)
 


### PR DESCRIPTION
Related CMake error was:
> CMake Deprecation Error at CMakeLists.txt:37 (cmake_minimum_required):
>   Compatibility with CMake < 3.5 will be removed from a future version of
>   CMake.
>
>   Update the VERSION argument <min> value or use a ...<max> suffix to tell
>   CMake that the project does not need compatibility with older versions.