### PR TITLE
Protect against integer overflow in `ComposeQueryEngine` (related to #183)

### DIFF
--- a/src/UriQuery.c
+++ b/src/UriQuery.c
@@ -70,6 +70,7 @@
 
 
 #include <limits.h>
+#include <stddef.h> /* size_t */
 
 
 
@@ -218,16 +219,16 @@ int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest,
 		const URI_CHAR * const key = queryList->key;
 		const URI_CHAR * const value = queryList->value;
 		const int worstCase = (normalizeBreaks == URI_TRUE ? 6 : 3);
-		const int keyLen = (key == NULL) ? 0 : (int)URI_STRLEN(key);
+		const size_t keyLen = (key == NULL) ? 0 : URI_STRLEN(key);
 		int keyRequiredChars;
-		const int valueLen = (value == NULL) ? 0 : (int)URI_STRLEN(value);
+		const size_t valueLen = (value == NULL) ? 0 : URI_STRLEN(value);
 		int valueRequiredChars;
 
-		if ((keyLen >= INT_MAX / worstCase) || (valueLen >= INT_MAX / worstCase)) {
+		if ((keyLen >= (size_t)INT_MAX / worstCase) || (valueLen >= (size_t)INT_MAX / worstCase)) {
 			return URI_ERROR_OUTPUT_TOO_LARGE;
 		}
-		keyRequiredChars = worstCase * keyLen;
-		valueRequiredChars = worstCase * valueLen;
+		keyRequiredChars = worstCase * (int)keyLen;
+		valueRequiredChars = worstCase * (int)valueLen;
 
 		if (dest == NULL) {
 			(*charsRequired) += ampersandLen + keyRequiredChars + ((value == NULL)


### PR DESCRIPTION
Requires string input that is longer than `INT_MAX` to exploit.

Related to issue #183