### PR TITLE
Add alias uriparser::uriparser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,8 @@ add_library(uriparser
     ${LIBRARY_CODE_FILES}
 )
 
+add_library(uriparser::uriparser ALIAS uriparser)
+
 if(NOT MSVC)
     math(EXPR URIPARSER_SO_CURRENT_MINUS_AGE "${URIPARSER_SO_CURRENT} - ${URIPARSER_SO_AGE}")
     set_property(TARGET uriparser PROPERTY VERSION ${URIPARSER_SO_CURRENT_MINUS_AGE}.${URIPARSER_SO_AGE}.${URIPARSER_SO_REVISION})


### PR DESCRIPTION
uriparser is exported as uriparser::uriparser so I added this alias here also. Otherwise devs would have to differentiate if they found the lib with find_package or are chainbuilding with i.e. fetchcontent