### PR TITLE
Fix CI / `build-and-test.yml`: Fix mishandling of package `debsuryorg-archive-keyring`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -69,7 +69,7 @@ jobs:
           #   2. Revert (remaining) packages that ppa:ondrej/php and plain Ubuntu share, back to the plain Ubuntu version
           #   3. Assert that no packages from ppa:ondrej/php are left installed
           dpkg -l | grep '^ii' | fgrep deb.sury.org | awk '{print $2}' | grep '^php' \
-            | xargs -r -t sudo apt-get remove --yes libpcre2-posix3 libzip4
+            | xargs -r -t sudo apt-get remove --yes debsuryorg-archive-keyring libpcre2-posix3 libzip4
           dpkg -l | grep '^ii' | fgrep deb.sury.org | awk '{print $2}' | sed "s,\$,/${UBUNTU_CODENAME}," \
             | xargs -r -t sudo apt-get install --yes --no-install-recommends --allow-downgrades -V
           ! dpkg -l | grep '^ii' | fgrep deb.sury.org


### PR DESCRIPTION
There is no package `debsuryorg-archive-keyring` in Ubuntu `focal`, so it has to be excluded from the list of packages that are reverted back to Ubuntu focal.

Symptom was:
```console
# sudo apt-get install --yes --no-install-recommends --allow-downgrades -V \
    debsuryorg-archive-keyring/focal libgd3:amd64/focal libhashkit2:amd64/focal \
    libmemcached11:amd64/focal libpcre2-16-0:amd64/focal libpcre2-32-0:amd64/focal \
    libpcre2-8-0:amd64/focal
Reading package lists...
Building dependency tree...
Reading state information...
E: Release 'focal' for 'debsuryorg-archive-keyring' was not found
```