### PR TITLE
Fix CI / Require CMake >=3.10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.10.0)
 
 project(uriparser
     VERSION

--- a/cmake/test_find_package/CMakeLists.txt
+++ b/cmake/test_find_package/CMakeLists.txt
@@ -34,7 +34,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.10.0)
 
 project(test-find-package VERSION 1.0)
 


### PR DESCRIPTION
.. to address this CMake warning:
```
CMake Deprecation Error at CMakeLists.txt:37 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <minvalue or use a ...<maxsuffix to tell
  CMake that the project does not need compatibility with older versions.
```