### PR TITLE
Fix fuzzers build for i386 architecture

### DIFF
--- a/fuzz/FuzzingUtils.h
+++ b/fuzz/FuzzingUtils.h
@@ -38,7 +38,7 @@ inline UriString tryConsumeBytesAsString(FuzzedDataProvider & fdp, size_t chars)
 
 inline UriString consumeRandomLengthString(FuzzedDataProvider & fdp) {
 	const size_t max_chars = fdp.remaining_bytes() / sizeof(URI_CHAR);
-	const size_t chars = fdp.ConsumeIntegralInRange(0ul, max_chars);
+	const size_t chars = fdp.ConsumeIntegralInRange<size_t>(0, max_chars);
 	return tryConsumeBytesAsString(fdp, chars);
 }
 


### PR DESCRIPTION
Adjustment after https://github.com/uriparser/uriparser/pull/209

```
[ 75%] Building CXX object CMakeFiles/uri_dissect_query_malloc_fuzzer.dir/fuzz/DissectQueryMallocFuzzer.cpp.o
In file included from /src/uriparser/fuzz/DissectQueryMallocFuzzer.cpp:17:
/src/uriparser/fuzz/FuzzingUtils.h:41:27: error: no matching member function for call to 'ConsumeIntegralInRange'
   41 |         const size_t chars = fdp.ConsumeIntegralInRange(0ul, max_chars);
      |                              ~~~~^~~~~~~~~~~~~~~~~~~~~~
/usr/local/lib/clang/18/include/fuzzer/FuzzedDataProvider.h:204:23: note: candidate template ignored: deduced conflicting types for parameter 'T' ('unsigned long' vs. 'size_t' (aka 'unsigned int'))
  204 | T FuzzedDataProvider::ConsumeIntegralInRange(T min, T max) {
      |                       ^
1 error generated.
```

SA: https://github.com/google/oss-fuzz/actions/runs/12622989282/job/35171510718?pr=12906