### PR TITLE
`fuzz/ParseFuzzer.cpp`: Fix `maxChars` input for call to `uriToStringW`

### DIFF
--- a/fuzz/ParseFuzzer.cpp
+++ b/fuzz/ParseFuzzer.cpp
@@ -110,7 +110,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size) {
 
 	URI_CHAR buf[1024 * 8] = {0};
 	int written = 0;
-	URI_FUNC(ToString)(buf, state1.uri, sizeof(buf), &written);
+	URI_FUNC(ToString)(buf, state1.uri, sizeof(buf) / sizeof(buf[0]), &written);
 
 	UriHolder uriHolder2;
 	if (URI_FUNC(ParseSingleUri)(uriHolder2.get(), uri2.c_str(), nullptr) != URI_SUCCESS) {


### PR DESCRIPTION
- Reported: `Mon, Jan 13, 2025, 1:03 PM`
- OSS-Fuzz issue: https://issues.oss-fuzz.com/issues/389731913
- Detailed Report: https://oss-fuzz.com/testcase?key=6067233314373632
- Regressed: https://oss-fuzz.com/revisions?job=libfuzzer_ubsan_uriparser&range=202501060601:202501070634
- Reproducer Testcase: https://oss-fuzz.com/download?testcase_id=6067233314373632

CC @tyler92 