### PR TITLE
Bump to Ubuntu 24.04

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
               -DCMAKE_SYSTEM_NAME=Windows
               -DWIN32=ON
               -DMINGW=ON
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   run_fuzzers:
     name: Run fuzzing regression tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 


### PR DESCRIPTION
Ubuntu 20.04 is about to be removed on 2025-04-01.