### PR TITLE
Normalized percent-encoded octets should have uppercase letters in the host (fixes #221)

### DIFF
--- a/src/UriNormalize.c
+++ b/src/UriNormalize.c
@@ -636,9 +636,8 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
 				uri->hostText.first = uri->hostData.ipFuture.first;
 				uri->hostText.afterLast = uri->hostData.ipFuture.afterLast;
 			} else if ((uri->hostText.first != NULL)
-					&& (uri->hostData.ip4 == NULL)
-					&& (uri->hostData.ip6 == NULL)) {
-				/* Regname */
+					&& (uri->hostData.ip4 == NULL)) {
+				/* Regname or IPv6 */
 				if (uri->owner) {
 					URI_FUNC(FixPercentEncodingInplace)(uri->hostText.first,
 							&(uri->hostText.afterLast));

--- a/src/UriNormalize.c
+++ b/src/UriNormalize.c
@@ -104,6 +104,8 @@ static UriBool URI_FUNC(ContainsUglyPercentEncoding)(const URI_CHAR * first,
 
 static void URI_FUNC(LowercaseInplace)(const URI_CHAR * first,
 		const URI_CHAR * afterLast);
+static void URI_FUNC(LowercaseInplaceExceptPercentEncoding)(const URI_CHAR * first,
+		const URI_CHAR * afterLast);
 static UriBool URI_FUNC(LowercaseMalloc)(const URI_CHAR ** first,
 		const URI_CHAR ** afterLast, UriMemoryManager * memory);
 
@@ -238,6 +240,26 @@ static URI_INLINE void URI_FUNC(LowercaseInplace)(const URI_CHAR * first,
 		for (; i < afterLast; i++) {
 			if ((*i >= _UT('A')) && (*i <=_UT('Z'))) {
 				*i = (URI_CHAR)(*i + lowerUpperDiff);
+			}
+		}
+	}
+}
+
+
+
+static URI_INLINE void URI_FUNC(LowercaseInplaceExceptPercentEncoding)(const URI_CHAR * first,
+		const URI_CHAR * afterLast) {
+	if ((first != NULL) && (afterLast != NULL) && (afterLast > first)) {
+		URI_CHAR * i = (URI_CHAR *)first;
+		const int lowerUpperDiff = (_UT('a') - _UT('A'));
+		for (; i < afterLast; i++) {
+			if ((*i >= _UT('A')) && (*i <=_UT('Z'))) {
+				*i = (URI_CHAR)(*i + lowerUpperDiff);
+			} else if (*i == _UT('%')) {
+				if (i + 3 >= afterLast) {
+					return;
+				}
+				i += 2;
 			}
 		}
 	}
@@ -631,7 +653,7 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
 					doneMask |= URI_NORMALIZE_HOST;
 				}
 
-				URI_FUNC(LowercaseInplace)(uri->hostText.first,
+				URI_FUNC(LowercaseInplaceExceptPercentEncoding)(uri->hostText.first,
 						uri->hostText.afterLast);
 			}
 		}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1460,6 +1460,10 @@ TEST(UriSuite, TestNormalizeSyntax) {
 				L"https://%E4%BD%A0%E5%A5%BD%E4%BD%A0%E5%A5%BD.com"));
 
 		ASSERT_TRUE(testNormalizeSyntaxHelper(
+				L"https://[2041:0000:140F::875B:131B]",
+				L"https://[2041:0000:140f::875b:131b]"));
+
+		ASSERT_TRUE(testNormalizeSyntaxHelper(
 				L"HTTP://a:b@HOST:123/./1/2/../%41?abc#def",
 				L"http://a:b@host:123/1/A?abc#def"));
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1456,6 +1456,10 @@ TEST(UriSuite, TestNormalizeSyntax) {
 				L"http://user:pass@somehost.com:123"));
 
 		ASSERT_TRUE(testNormalizeSyntaxHelper(
+				L"https://%e4%bd%a0%e5%a5%bd%e4%bd%a0%e5%a5%bd.com",
+				L"https://%E4%BD%A0%E5%A5%BD%E4%BD%A0%E5%A5%BD.com"));
+
+		ASSERT_TRUE(testNormalizeSyntaxHelper(
 				L"HTTP://a:b@HOST:123/./1/2/../%41?abc#def",
 				L"http://a:b@host:123/1/A?abc#def"));
 


### PR DESCRIPTION
A simple solution that skips lowercasing 2 characters after each `%`.

Fixes #221