### PR TITLE
Fix #200 Add support for copying Uri structures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,8 @@ set(LIBRARY_CODE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriCommon.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriCommon.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriCompare.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/UriCopy.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/UriCopy.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriEscape.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriFile.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriIp4Base.c
@@ -157,6 +159,7 @@ set(LIBRARY_CODE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriNormalizeBase.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriNormalizeBase.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriNormalize.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/UriNormalize.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriParseBase.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriParseBase.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriParse.c
@@ -283,6 +286,7 @@ if(URIPARSER_BUILD_TESTS)
     find_package(GTest 1.8.0 REQUIRED)
 
     add_executable(testrunner
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/copy.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test/FourSuite.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test/MemoryManagerSuite.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test/test.cpp

--- a/include/uriparser/Uri.h
+++ b/include/uriparser/Uri.h
@@ -656,6 +656,36 @@ URI_PUBLIC int URI_FUNC(ToString)(URI_CHAR * dest, const URI_TYPE(Uri) * uri,
 
 
 /**
+ * Copies a %URI structure.
+ *
+ * @param destUri        <b>OUT</b>: Output destination
+ * @param sourceUri      <b>IN</b>: %URI to copy
+ * @param memory         <b>IN</b>: Memory manager to use, NULL for default libc
+ * @return               Error code or 0 on success
+ *
+ * @see uriCopyUriA
+ * @since 0.9.9
+ */
+URI_PUBLIC int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
+		const URI_TYPE(Uri) * sourceUri, UriMemoryManager * memory);
+
+
+
+/**
+ * Copies a %URI structure.
+ *
+ * @param destUri        <b>OUT</b>: Output destination
+ * @param sourceUri      <b>IN</b>: %URI to copy
+ * @return               Error code or 0 on success
+ *
+ * @see uriCopyUriMmA
+ * @since 0.9.9
+ */
+URI_PUBLIC int URI_FUNC(CopyUri)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri);
+
+
+
+/**
  * Determines the components of a %URI that are not normalized.
  *
  * @param uri   <b>IN</b>: %URI to check

--- a/src/UriCommon.c
+++ b/src/UriCommon.c
@@ -119,6 +119,23 @@ int URI_FUNC(CompareRange)(
 
 
 
+UriBool URI_FUNC(CopyRange)(URI_TYPE(TextRange) * destRange,
+		const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory) {
+	const int lenInChars = (int)(sourceRange->afterLast - sourceRange->first);
+	const int lenInBytes = lenInChars * sizeof(URI_CHAR);
+	URI_CHAR * dup = memory->malloc(memory, lenInBytes);
+	if (dup == NULL) {
+		return URI_FALSE;
+	}
+	memcpy(dup, sourceRange->first, lenInBytes);
+	destRange->first = dup;
+	destRange->afterLast = dup + lenInChars;
+
+	return URI_TRUE;
+}
+
+
+
 UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri,
 		UriBool relative, UriBool pathOwned, UriMemoryManager * memory) {
 	URI_TYPE(PathSegment) * walker;

--- a/src/UriCommon.c
+++ b/src/UriCommon.c
@@ -136,6 +136,23 @@ UriBool URI_FUNC(CopyRange)(URI_TYPE(TextRange) * destRange,
 
 
 
+UriBool URI_FUNC(CopyRangeAsNeeded)(URI_TYPE(TextRange) * destRange,
+		const URI_TYPE(TextRange) * sourceRange, UriBool useSafe, UriMemoryManager * memory) {
+	if (sourceRange->first == NULL) {
+		destRange->first = NULL;
+		destRange->afterLast = NULL;
+	} else if (sourceRange->first == sourceRange->afterLast && useSafe) {
+		destRange->first = URI_FUNC(SafeToPointTo);
+		destRange->afterLast = URI_FUNC(SafeToPointTo);
+	} else {
+		return URI_FUNC(CopyRange)(destRange, sourceRange, memory);
+	}
+
+	return URI_TRUE;
+}
+
+
+
 UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri,
 		UriBool relative, UriBool pathOwned, UriMemoryManager * memory) {
 	URI_TYPE(PathSegment) * walker;

--- a/src/UriCommon.h
+++ b/src/UriCommon.h
@@ -82,6 +82,9 @@ int URI_FUNC(CompareRange)(
 		const URI_TYPE(TextRange) * a,
 		const URI_TYPE(TextRange) * b);
 
+UriBool URI_FUNC(CopyRange)(URI_TYPE(TextRange) * destRange,
+		const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory);
+
 UriBool URI_FUNC(RemoveDotSegmentsAbsolute)(URI_TYPE(Uri) * uri,
 		UriMemoryManager * memory);
 UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri,

--- a/src/UriCopy.c
+++ b/src/UriCopy.c
@@ -1,0 +1,234 @@
+/*
+ * uriparser - RFC 3986 URI parsing library
+ *
+ * Copyright (C) 2007, Weijia Song <songweijia@gmail.com>
+ * Copyright (C) 2007, Sebastian Pipping <sebastian@pipping.org>
+ * Copyright (C) 2025, Máté Kocsis <kocsismate@php.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source  and binary forms, with or without
+ * modification, are permitted provided  that the following conditions
+ * are met:
+ *
+ *     1. Redistributions  of  source  code   must  retain  the  above
+ *        copyright notice, this list  of conditions and the following
+ *        disclaimer.
+ *
+ *     2. Redistributions  in binary  form  must  reproduce the  above
+ *        copyright notice, this list  of conditions and the following
+ *        disclaimer  in  the  documentation  and/or  other  materials
+ *        provided with the distribution.
+ *
+ *     3. Neither the  name of the  copyright holder nor the  names of
+ *        its contributors may be used  to endorse or promote products
+ *        derived from  this software  without specific  prior written
+ *        permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND  ANY EXPRESS OR IMPLIED WARRANTIES,  INCLUDING, BUT NOT
+ * LIMITED TO,  THE IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS
+ * FOR  A  PARTICULAR  PURPOSE  ARE  DISCLAIMED.  IN  NO  EVENT  SHALL
+ * THE  COPYRIGHT HOLDER  OR CONTRIBUTORS  BE LIABLE  FOR ANY  DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL,  EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA,  OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT  LIABILITY,  OR  TORT (INCLUDING  NEGLIGENCE  OR  OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file UriCopy.c
+ * Holds the RFC 3986 %URI normalization implementation.
+ * NOTE: This source file includes itself twice.
+ */
+
+/* What encodings are enabled? */
+#include <uriparser/UriDefsConfig.h>
+#if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+/* Include SELF twice */
+# ifdef URI_ENABLE_ANSI
+#  define URI_PASS_ANSI 1
+#  include "UriCopy.c"
+#  undef URI_PASS_ANSI
+# endif
+# ifdef URI_ENABLE_UNICODE
+#  define URI_PASS_UNICODE 1
+#  include "UriCopy.c"
+#  undef URI_PASS_UNICODE
+# endif
+#else
+# ifdef URI_PASS_ANSI
+#  include <uriparser/UriDefsAnsi.h>
+# else
+#  include <uriparser/UriDefsUnicode.h>
+#  include <wchar.h>
+# endif
+
+
+
+#ifndef URI_DOXYGEN
+# include <uriparser/Uri.h>
+# include "UriCommon.h"
+# include "UriMemory.h"
+# include "UriNormalize.h"
+# include "UriCopy.h"
+#endif
+
+
+
+static void URI_FUNC(PreventLeakageAfterCopy)(URI_TYPE(Uri) * uri,
+		unsigned int revertMask, UriMemoryManager * memory) {
+	URI_FUNC(PreventLeakage)(uri, revertMask, memory);
+
+	if (uri->hostData.ip4 != NULL) {
+		memory->free(memory, uri->hostData.ip4);
+		uri->hostData.ip4 = NULL;
+	} else if (uri->hostData.ip6 != NULL) {
+		memory->free(memory, uri->hostData.ip6);
+		uri->hostData.ip6 = NULL;
+	}
+
+	if (revertMask & URI_NORMALIZE_PORT) {
+		if (uri->portText.first != uri->portText.afterLast) {
+			memory->free(memory, (URI_CHAR *)uri->portText.first);
+		}
+		uri->portText.first = NULL;
+		uri->portText.afterLast = NULL;
+	}
+}
+
+
+
+int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
+		 const URI_TYPE(Uri) * sourceUri, UriMemoryManager * memory) {
+	unsigned int doneMask = URI_NORMALIZED;
+
+	if (sourceUri == NULL || destUri == NULL) {
+		return URI_ERROR_NULL;
+	}
+
+	URI_CHECK_MEMORY_MANAGER(memory); /* may return */
+
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->scheme, &sourceUri->scheme, URI_FALSE, memory) == URI_FALSE) {
+		return URI_ERROR_MALLOC;
+	}
+
+	doneMask |= URI_NORMALIZE_SCHEME;
+
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->userInfo, &sourceUri->userInfo, URI_FALSE, memory) == URI_FALSE) {
+		URI_FUNC(PreventLeakageAfterCopy)(destUri, doneMask, memory);
+		return URI_ERROR_MALLOC;
+	}
+
+	doneMask |= URI_NORMALIZE_USER_INFO;
+
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->hostText, &sourceUri->hostText, URI_TRUE, memory) == URI_FALSE) {
+		URI_FUNC(PreventLeakageAfterCopy)(destUri, doneMask, memory);
+		return URI_ERROR_MALLOC;
+	}
+
+	doneMask |= URI_NORMALIZE_HOST;
+
+	if (sourceUri->hostData.ip4 == NULL) {
+		destUri->hostData.ip4 = NULL;
+	} else {
+		destUri->hostData.ip4 = memory->malloc(memory, sizeof(UriIp4));
+		if (destUri->hostData.ip4 == NULL) {
+			URI_FUNC(PreventLeakageAfterCopy)(destUri, doneMask, memory);
+			return URI_ERROR_MALLOC;
+		}
+		*(destUri->hostData.ip4) = *(sourceUri->hostData.ip4);
+	}
+
+	if (sourceUri->hostData.ip6 == NULL) {
+		destUri->hostData.ip6 = NULL;
+	} else {
+		destUri->hostData.ip6 = memory->malloc(memory, sizeof(UriIp6));
+		if (destUri->hostData.ip6 == NULL) {
+			URI_FUNC(PreventLeakageAfterCopy)(destUri, doneMask, memory);
+			return URI_ERROR_MALLOC;
+		}
+		*(destUri->hostData.ip6) = *(sourceUri->hostData.ip6);
+	}
+
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->hostData.ipFuture, &sourceUri->hostData.ipFuture, URI_FALSE, memory) == URI_FALSE) {
+		URI_FUNC(PreventLeakageAfterCopy)(destUri, doneMask, memory);
+		return URI_ERROR_MALLOC;
+	}
+
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->portText, &sourceUri->portText, URI_FALSE, memory) == URI_FALSE) {
+		URI_FUNC(PreventLeakageAfterCopy)(destUri, doneMask, memory);
+		return URI_ERROR_MALLOC;
+	}
+
+	doneMask |= URI_NORMALIZE_PORT;
+
+	destUri->pathHead = NULL;
+	destUri->pathTail = NULL;
+
+	if (sourceUri->pathHead != NULL) {
+		URI_TYPE(PathSegment) * sourceWalker = sourceUri->pathHead;
+		URI_TYPE(PathSegment) * destPrev = NULL;
+
+		while (sourceWalker != NULL) {
+			URI_TYPE(PathSegment) * destWalker = memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
+			if (destWalker == NULL) {
+				URI_FUNC(PreventLeakageAfterCopy)(destUri, doneMask, memory);
+				return URI_ERROR_MALLOC;
+			}
+
+			destWalker->text.first = NULL;
+			destWalker->text.afterLast = NULL;
+			destWalker->next = NULL;
+			destWalker->reserved = NULL;
+
+			if (destUri->pathHead == NULL) {
+				destUri->pathHead = destWalker;
+				doneMask |= URI_NORMALIZE_PATH;
+			}
+
+			if (URI_FUNC(CopyRangeAsNeeded)(&destWalker->text, &sourceWalker->text, URI_TRUE, memory) == URI_FALSE) {
+				URI_FUNC(PreventLeakageAfterCopy)(destUri, doneMask, memory);
+				return URI_ERROR_MALLOC;
+			}
+
+			if (destPrev != NULL) {
+				destPrev->next = destWalker;
+			}
+
+			destPrev = destWalker;
+			sourceWalker = sourceWalker->next;
+
+			destUri->pathTail = destWalker;
+		}
+	}
+
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->query, &sourceUri->query, URI_FALSE, memory) == URI_FALSE) {
+		URI_FUNC(PreventLeakageAfterCopy)(destUri, doneMask, memory);
+		return URI_ERROR_MALLOC;
+	}
+
+	doneMask |= URI_NORMALIZE_QUERY;
+
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->fragment, &sourceUri->fragment, URI_FALSE, memory) == URI_FALSE) {
+		URI_FUNC(PreventLeakageAfterCopy)(destUri, doneMask, memory);
+		return URI_ERROR_MALLOC;
+	}
+
+	destUri->absolutePath = sourceUri->absolutePath;
+	destUri->owner = URI_TRUE;
+	destUri->reserved = NULL;
+
+	return URI_SUCCESS;
+}
+
+
+
+int URI_FUNC(CopyUri)(URI_TYPE(Uri) * destUri,
+		const URI_TYPE(Uri) * sourceUri) {
+	return URI_FUNC(CopyUriMm)(destUri, sourceUri, NULL);
+}
+
+#endif

--- a/src/UriCopy.h
+++ b/src/UriCopy.h
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2007, Weijia Song <songweijia@gmail.com>
  * Copyright (C) 2007, Sebastian Pipping <sebastian@pipping.org>
+ * Copyright (C) 2025, Máté Kocsis <kocsismate@php.net>
  * All rights reserved.
  *
  * Redistribution and use in source  and binary forms, with or without
@@ -37,8 +38,8 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if (defined(URI_PASS_ANSI) && !defined(URI_COMMON_H_ANSI)) \
-	|| (defined(URI_PASS_UNICODE) && !defined(URI_COMMON_H_UNICODE)) \
+#if (defined(URI_PASS_ANSI) && !defined(URI_COPY_H_ANSI)) \
+	|| (defined(URI_PASS_UNICODE) && !defined(URI_COPY_H_UNICODE)) \
 	|| (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* What encodings are enabled? */
 #include <uriparser/UriDefsConfig.h>
@@ -46,65 +47,32 @@
 /* Include SELF twice */
 # ifdef URI_ENABLE_ANSI
 #  define URI_PASS_ANSI 1
-#  include "UriCommon.h"
+#  include "UriCopy.h"
 #  undef URI_PASS_ANSI
 # endif
 # ifdef URI_ENABLE_UNICODE
 #  define URI_PASS_UNICODE 1
-#  include "UriCommon.h"
+#  include "UriCopy.h"
 #  undef URI_PASS_UNICODE
 # endif
 /* Only one pass for each encoding */
-#elif (defined(URI_PASS_ANSI) && !defined(URI_COMMON_H_ANSI) \
+#elif (defined(URI_PASS_ANSI) && !defined(URI_COPY_H_ANSI) \
 	&& defined(URI_ENABLE_ANSI)) || (defined(URI_PASS_UNICODE) \
-	&& !defined(URI_COMMON_H_UNICODE) && defined(URI_ENABLE_UNICODE))
+	&& !defined(URI_COPY_H_UNICODE) && defined(URI_ENABLE_UNICODE))
 # ifdef URI_PASS_ANSI
-#  define URI_COMMON_H_ANSI 1
+#  define URI_COPY_H_ANSI 1
 #  include <uriparser/UriDefsAnsi.h>
 # else
-#  define URI_COMMON_H_UNICODE 1
+#  define URI_COPY_H_UNICODE 1
 #  include <uriparser/UriDefsUnicode.h>
 # endif
 
 
 
-/* Used to point to from empty path segments.
- * X.first and X.afterLast must be the same non-NULL value then. */
-extern const URI_CHAR * const URI_FUNC(SafeToPointTo);
-extern const URI_CHAR * const URI_FUNC(ConstPwd);
-extern const URI_CHAR * const URI_FUNC(ConstParent);
-
-
-
-void URI_FUNC(ResetUri)(URI_TYPE(Uri) * uri);
-
-int URI_FUNC(CompareRange)(
-		const URI_TYPE(TextRange) * a,
-		const URI_TYPE(TextRange) * b);
-
-UriBool URI_FUNC(CopyRange)(URI_TYPE(TextRange) * destRange,
-		const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory);
-UriBool URI_FUNC(CopyRangeAsNeeded)(URI_TYPE(TextRange) * destRange,
-		const URI_TYPE(TextRange) * sourceRange, UriBool useSafe, UriMemoryManager * memory);
-
-UriBool URI_FUNC(RemoveDotSegmentsAbsolute)(URI_TYPE(Uri) * uri,
-		UriMemoryManager * memory);
-UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri,
-		UriBool relative, UriBool pathOwned, UriMemoryManager * memory);
-
-unsigned char URI_FUNC(HexdigToInt)(URI_CHAR hexdig);
-URI_CHAR URI_FUNC(HexToLetter)(unsigned int value);
-URI_CHAR URI_FUNC(HexToLetterEx)(unsigned int value, UriBool uppercase);
-
-UriBool URI_FUNC(CopyPath)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source,
-		UriMemoryManager * memory);
-UriBool URI_FUNC(CopyAuthority)(URI_TYPE(Uri) * dest,
-		const URI_TYPE(Uri) * source, UriMemoryManager * memory);
-
-UriBool URI_FUNC(FixAmbiguity)(URI_TYPE(Uri) * uri, UriMemoryManager * memory);
-void URI_FUNC(FixEmptyTrailSegment)(URI_TYPE(Uri) * uri,
-		UriMemoryManager * memory);
-
+int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
+		const URI_TYPE(Uri) * sourceUri, UriMemoryManager * memory);
+int URI_FUNC(CopyUri)(URI_TYPE(Uri) * destUri,
+		const URI_TYPE(Uri) * sourceUri);
 
 #endif
 #endif

--- a/src/UriNormalize.c
+++ b/src/UriNormalize.c
@@ -109,12 +109,9 @@ static void URI_FUNC(LowercaseInplaceExceptPercentEncoding)(const URI_CHAR * fir
 static UriBool URI_FUNC(LowercaseMalloc)(const URI_CHAR ** first,
 		const URI_CHAR ** afterLast, UriMemoryManager * memory);
 
-static void URI_FUNC(PreventLeakage)(URI_TYPE(Uri) * uri,
-		unsigned int revertMask, UriMemoryManager * memory);
 
 
-
-static URI_INLINE void URI_FUNC(PreventLeakage)(URI_TYPE(Uri) * uri,
+void URI_FUNC(PreventLeakage)(URI_TYPE(Uri) * uri,
 		unsigned int revertMask, UriMemoryManager * memory) {
 	if (revertMask & URI_NORMALIZE_SCHEME) {
 		/* NOTE: A scheme cannot be the empty string

--- a/src/UriNormalize.c
+++ b/src/UriNormalize.c
@@ -407,15 +407,9 @@ static URI_INLINE UriBool URI_FUNC(MakeRangeOwner)(unsigned int * doneMask,
 			&& (range->first != NULL)
 			&& (range->afterLast != NULL)
 			&& (range->afterLast > range->first)) {
-		const int lenInChars = (int)(range->afterLast - range->first);
-		const int lenInBytes = lenInChars * sizeof(URI_CHAR);
-		URI_CHAR * dup = memory->malloc(memory, lenInBytes);
-		if (dup == NULL) {
-			return URI_FALSE; /* Raises malloc error */
+		if (URI_FUNC(CopyRange)(range, range, memory) == URI_FALSE) {
+			return URI_FALSE;
 		}
-		memcpy(dup, range->first, lenInBytes);
-		range->first = dup;
-		range->afterLast = dup + lenInChars;
 		*doneMask |= maskTest;
 	}
 	return URI_TRUE;

--- a/src/UriNormalize.h
+++ b/src/UriNormalize.h
@@ -1,8 +1,9 @@
 /*
  * uriparser - RFC 3986 URI parsing library
  *
- * Copyright (C) 2007, Weijia Song <songweijia@gmail.com>
- * Copyright (C) 2007, Sebastian Pipping <sebastian@pipping.org>
+ * Copyright (C) 2018, Weijia Song <songweijia@gmail.com>
+ * Copyright (C) 2018, Sebastian Pipping <sebastian@pipping.org>
+ * Copyright (C) 2025, Máté Kocsis <kocsismate@php.net>
  * All rights reserved.
  *
  * Redistribution and use in source  and binary forms, with or without
@@ -37,8 +38,8 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if (defined(URI_PASS_ANSI) && !defined(URI_COMMON_H_ANSI)) \
-	|| (defined(URI_PASS_UNICODE) && !defined(URI_COMMON_H_UNICODE)) \
+#if (defined(URI_PASS_ANSI) && !defined(URI_NORMALIZE_H_ANSI)) \
+	|| (defined(URI_PASS_UNICODE) && !defined(URI_NORMALIZE_H_UNICODE)) \
 	|| (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* What encodings are enabled? */
 #include <uriparser/UriDefsConfig.h>
@@ -46,65 +47,30 @@
 /* Include SELF twice */
 # ifdef URI_ENABLE_ANSI
 #  define URI_PASS_ANSI 1
-#  include "UriCommon.h"
+#  include "UriNormalize.h"
 #  undef URI_PASS_ANSI
 # endif
 # ifdef URI_ENABLE_UNICODE
 #  define URI_PASS_UNICODE 1
-#  include "UriCommon.h"
+#  include "UriNormalize.h"
 #  undef URI_PASS_UNICODE
 # endif
 /* Only one pass for each encoding */
-#elif (defined(URI_PASS_ANSI) && !defined(URI_COMMON_H_ANSI) \
+#elif (defined(URI_PASS_ANSI) && !defined(URI_NORMALIZE_H_ANSI) \
 	&& defined(URI_ENABLE_ANSI)) || (defined(URI_PASS_UNICODE) \
-	&& !defined(URI_COMMON_H_UNICODE) && defined(URI_ENABLE_UNICODE))
+	&& !defined(URI_NORMALIZE_H_UNICODE) && defined(URI_ENABLE_UNICODE))
 # ifdef URI_PASS_ANSI
-#  define URI_COMMON_H_ANSI 1
+#  define URI_NORMALIZE_H_ANSI 1
 #  include <uriparser/UriDefsAnsi.h>
 # else
-#  define URI_COMMON_H_UNICODE 1
+#  define URI_NORMALIZE_H_UNICODE 1
 #  include <uriparser/UriDefsUnicode.h>
 # endif
 
 
 
-/* Used to point to from empty path segments.
- * X.first and X.afterLast must be the same non-NULL value then. */
-extern const URI_CHAR * const URI_FUNC(SafeToPointTo);
-extern const URI_CHAR * const URI_FUNC(ConstPwd);
-extern const URI_CHAR * const URI_FUNC(ConstParent);
-
-
-
-void URI_FUNC(ResetUri)(URI_TYPE(Uri) * uri);
-
-int URI_FUNC(CompareRange)(
-		const URI_TYPE(TextRange) * a,
-		const URI_TYPE(TextRange) * b);
-
-UriBool URI_FUNC(CopyRange)(URI_TYPE(TextRange) * destRange,
-		const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory);
-UriBool URI_FUNC(CopyRangeAsNeeded)(URI_TYPE(TextRange) * destRange,
-		const URI_TYPE(TextRange) * sourceRange, UriBool useSafe, UriMemoryManager * memory);
-
-UriBool URI_FUNC(RemoveDotSegmentsAbsolute)(URI_TYPE(Uri) * uri,
-		UriMemoryManager * memory);
-UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri,
-		UriBool relative, UriBool pathOwned, UriMemoryManager * memory);
-
-unsigned char URI_FUNC(HexdigToInt)(URI_CHAR hexdig);
-URI_CHAR URI_FUNC(HexToLetter)(unsigned int value);
-URI_CHAR URI_FUNC(HexToLetterEx)(unsigned int value, UriBool uppercase);
-
-UriBool URI_FUNC(CopyPath)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source,
-		UriMemoryManager * memory);
-UriBool URI_FUNC(CopyAuthority)(URI_TYPE(Uri) * dest,
-		const URI_TYPE(Uri) * source, UriMemoryManager * memory);
-
-UriBool URI_FUNC(FixAmbiguity)(URI_TYPE(Uri) * uri, UriMemoryManager * memory);
-void URI_FUNC(FixEmptyTrailSegment)(URI_TYPE(Uri) * uri,
-		UriMemoryManager * memory);
-
+void URI_FUNC(PreventLeakage)(URI_TYPE(Uri) * uri,
+		unsigned int revertMask, UriMemoryManager * memory);
 
 #endif
 #endif

--- a/test/copy.cpp
+++ b/test/copy.cpp
@@ -1,0 +1,155 @@
+/*
+ * uriparser - RFC 3986 URI parsing library
+ *
+ * Copyright (C) 2007, Weijia Song <songweijia@gmail.com>
+ * Copyright (C) 2007, Sebastian Pipping <sebastian@pipping.org>
+ * Copyright (C) 2025, Máté Kocsis <kocsismate@php.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <uriparser/Uri.h>
+#include <uriparser/UriIp4.h>
+#include <gtest/gtest.h>
+#include <memory>
+#include <cstdio>
+#include <cstdlib>
+#include <cwchar>
+#include <string>
+
+using namespace std;
+
+namespace {
+	void testCopyUri(UriUriA * destUri, const char *const sourceUriString) {
+		UriUriA sourceUri;
+
+		ASSERT_EQ(uriParseSingleUriA(&sourceUri, sourceUriString, NULL), URI_SUCCESS);
+
+		ASSERT_EQ(URI_SUCCESS, uriCopyUriA(destUri, &sourceUri));
+		ASSERT_EQ(URI_TRUE, uriEqualsUriA(destUri, &sourceUri));
+
+		uriFreeUriMembersA(&sourceUri);
+	}
+} // namespace
+
+TEST(CopyUriSuite, ErrorSourceUriNull) {
+	UriUriA destUri;
+
+	ASSERT_EQ(uriCopyUriA(&destUri, NULL), URI_ERROR_NULL);
+}
+
+TEST(CopyUriSuite, ErrorDestUriNull) {
+	UriUriA sourceUri;
+	const char * const sourceUriString = "https://example.com";
+
+	ASSERT_EQ(uriParseSingleUriA(&sourceUri, sourceUriString, NULL), URI_SUCCESS);
+
+	ASSERT_EQ(URI_ERROR_NULL, uriCopyUriA(NULL, &sourceUri));
+
+	uriFreeUriMembersA(&sourceUri);
+}
+
+TEST(CopyUriSuite, ErrorIncompleteMemoryManager) {
+	UriUriA sourceUri;
+	const char * const sourceUriString = "https://example.com";
+	UriMemoryManager memory = {NULL, NULL, NULL, NULL, NULL, NULL};
+
+	ASSERT_EQ(uriParseSingleUriA(&sourceUri, sourceUriString, NULL), URI_SUCCESS);
+
+	UriUriA destUri;
+	ASSERT_EQ(URI_ERROR_MEMORY_MANAGER_INCOMPLETE, uriCopyUriMmA(&destUri, &sourceUri, &memory));
+
+	uriFreeUriMembersA(&sourceUri);
+}
+
+TEST(CopyUriSuite, SuccessRegName) {
+	UriUriA destUri;
+	testCopyUri(&destUri, "https://somehost.com");
+
+	ASSERT_TRUE(destUri.hostData.ip4 == NULL);
+	ASSERT_TRUE(destUri.hostData.ip6 == NULL);
+	ASSERT_TRUE(destUri.hostData.ipFuture.first == NULL);
+	ASSERT_TRUE(destUri.hostData.ipFuture.afterLast == NULL);
+	ASSERT_EQ(0, strncmp(destUri.hostText.first, "somehost.com", strlen("somehost.com")));
+
+	uriFreeUriMembersA(&destUri);
+}
+
+TEST(CopyUriSuite, SuccessCompleteUri) {
+	UriUriA destUri;
+	testCopyUri(&destUri, "https://user:pass@somehost.com:80/path?query#frag");
+
+	uriFreeUriMembersA(&destUri);
+}
+
+TEST(CopyUriSuite, SuccessRelativeReference) {
+	UriUriA destUri;
+	testCopyUri(&destUri, "/foo/bar/baz");
+
+	uriFreeUriMembersA(&destUri);
+}
+
+TEST(CopyUriSuite, SuccessEmail) {
+	UriUriA destUri;
+	testCopyUri(&destUri, "mailto:fred@example.com");
+
+	uriFreeUriMembersA(&destUri);
+}
+
+TEST(CopyUriSuite, SuccessIpV4) {
+	UriUriA destUri;
+	testCopyUri(&destUri, "http://192.168.0.1/");
+
+	const unsigned char expected[4] = {192, 168, 0, 1};
+	ASSERT_EQ(memcmp(expected, destUri.hostData.ip4->data, sizeof(expected)), 0);
+
+	ASSERT_TRUE(destUri.hostData.ip6 == NULL);
+	ASSERT_TRUE(destUri.hostData.ipFuture.first == NULL);
+	ASSERT_TRUE(destUri.hostData.ipFuture.afterLast == NULL);
+	ASSERT_EQ(0, strncmp(destUri.hostText.first, "192.168.0.1", strlen("192.168.0.1")));
+
+	uriFreeUriMembersA(&destUri);
+}
+
+TEST(CopyUriSuite, SuccessIpV6) {
+	UriUriA destUri;
+	testCopyUri(&destUri, "https://[2001:0db8:0001:0000:0000:0ab9:c0a8:0102]");  // RFC 3849
+
+	const unsigned char expected[16] = {
+		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x0a, 0xb9, 0xc0, 0xa8, 0x01, 0x02
+	};
+	ASSERT_EQ(memcmp(expected, destUri.hostData.ip6->data, sizeof(expected)), 0);
+
+	ASSERT_TRUE(destUri.hostData.ip4 == NULL);
+	ASSERT_TRUE(destUri.hostData.ipFuture.first == NULL);
+	ASSERT_TRUE(destUri.hostData.ipFuture.afterLast == NULL);
+	ASSERT_EQ(0, strncmp(destUri.hostText.first,
+		"2001:0db8:0001:0000:0000:0ab9:c0a8:0102", strlen("2001:0db8:0001:0000:0000:0ab9:c0a8:0102")));
+
+	uriFreeUriMembersA(&destUri);
+}
+
+TEST(CopyUriSuite, SuccessIpFuture) {
+	UriUriA destUri;
+	testCopyUri(&destUri, "//[v7.host]/source");
+
+	ASSERT_EQ(0, strncmp(destUri.hostData.ipFuture.first, "v7.host", strlen("v7.host")));
+
+	ASSERT_TRUE(destUri.hostData.ip4 == NULL);
+	ASSERT_TRUE(destUri.hostData.ip6 == NULL);
+	ASSERT_EQ(0, strncmp(destUri.hostText.first, "v7.host", strlen("v7.host")));
+
+	uriFreeUriMembersA(&destUri);
+}


### PR DESCRIPTION
I also need this functionality for https://wiki.php.net/rfc/url_parsing_api because of multiple reasons:

- In order to maintain immutability of URIs, the structs have to be copied first before any modification
- The PHP `Uri` class exposes both the normalized and non-normalized URI components (therefore it internally stores two Uri structs). When a normalized component is requested, normalization is done on demand, by copying the original struct first

The patch needs a last few touches, including tests, but I wanted to propose it nevertheless to get early feedback.