### PR TITLE
Add function `HasHost` to the public API

### DIFF
--- a/include/uriparser/Uri.h
+++ b/include/uriparser/Uri.h
@@ -209,7 +209,7 @@ typedef struct URI_TYPE(QueryListStruct) {
  *
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsHostSet)(const URI_TYPE(Uri) * uri);
+URI_PUBLIC UriBool URI_FUNC(HasHost)(const URI_TYPE(Uri) * uri);
 
 
 

--- a/include/uriparser/Uri.h
+++ b/include/uriparser/Uri.h
@@ -201,6 +201,17 @@ typedef struct URI_TYPE(QueryListStruct) {
 } URI_TYPE(QueryList); /**< @copydoc UriQueryListStructA */
 
 
+/**
+ * Checks if a URI has the host component set.
+ *
+ * @param uri <b>IN</b>: %URI to check
+ * @return <c>URI_TRUE</c> when host is set, <c>URI_FALSE</c> otherwise
+ *
+ * @since 0.9.9
+ */
+URI_PUBLIC UriBool URI_FUNC(IsHostSet)(const URI_TYPE(Uri) * uri);
+
+
 
 /**
  * Parses a RFC 3986 %URI.

--- a/src/UriCommon.c
+++ b/src/UriCommon.c
@@ -189,7 +189,7 @@ UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri,
 
 						if (prev == NULL) {
 							/* Last and first */
-							if (URI_FUNC(IsHostSet)(uri)) {
+							if (URI_FUNC(HasHost)(uri)) {
 								/* Replace "." with empty segment to represent trailing slash */
 								walker->text.first = URI_FUNC(SafeToPointTo);
 								walker->text.afterLast = URI_FUNC(SafeToPointTo);
@@ -463,7 +463,7 @@ URI_CHAR URI_FUNC(HexToLetterEx)(unsigned int value, UriBool uppercase) {
 
 
 /* Checks if a URI has the host component set. */
-UriBool URI_FUNC(IsHostSet)(const URI_TYPE(Uri) * uri) {
+UriBool URI_FUNC(HasHost)(const URI_TYPE(Uri) * uri) {
 	return (uri != NULL)
 			&& ((uri->hostText.first != NULL)
 				|| (uri->hostData.ip4 != NULL)
@@ -601,7 +601,7 @@ void URI_FUNC(FixEmptyTrailSegment)(URI_TYPE(Uri) * uri,
 		UriMemoryManager * memory) {
 	/* Fix path if only one empty segment */
 	if (!uri->absolutePath
-			&& !URI_FUNC(IsHostSet)(uri)
+			&& !URI_FUNC(HasHost)(uri)
 			&& (uri->pathHead != NULL)
 			&& (uri->pathHead->next == NULL)
 			&& (uri->pathHead->text.first == uri->pathHead->text.afterLast)) {

--- a/src/UriCommon.h
+++ b/src/UriCommon.h
@@ -91,8 +91,6 @@ unsigned char URI_FUNC(HexdigToInt)(URI_CHAR hexdig);
 URI_CHAR URI_FUNC(HexToLetter)(unsigned int value);
 URI_CHAR URI_FUNC(HexToLetterEx)(unsigned int value, UriBool uppercase);
 
-UriBool URI_FUNC(IsHostSet)(const URI_TYPE(Uri) * uri);
-
 UriBool URI_FUNC(CopyPath)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source,
 		UriMemoryManager * memory);
 UriBool URI_FUNC(CopyAuthority)(URI_TYPE(Uri) * dest,

--- a/src/UriRecompose.c
+++ b/src/UriRecompose.c
@@ -152,7 +152,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest,
 	/* [05/19]	endif; */
 				}
 	/* [06/19]	if defined(authority) then */
-				if (URI_FUNC(IsHostSet)(uri)) {
+				if (URI_FUNC(HasHost)(uri)) {
 	/* [07/19]		append "//" to result; */
 					if (dest != NULL) {
 						if (written + 2 <= maxChars) {
@@ -422,7 +422,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest,
 	/* [10/19]	append path to result; */
 				/* Slash needed here? */
 				if (uri->absolutePath || ((uri->pathHead != NULL)
-						&& URI_FUNC(IsHostSet)(uri))) {
+						&& URI_FUNC(HasHost)(uri))) {
 					if (dest != NULL) {
 						if (written + 1 <= maxChars) {
 							memcpy(dest + written, _UT("/"),

--- a/src/UriResolve.c
+++ b/src/UriResolve.c
@@ -128,7 +128,7 @@ static int URI_FUNC(ResolveAbsolutePathFlag)(URI_TYPE(Uri) * absWork,
 		return URI_ERROR_NULL;
 	}
 
-	if (URI_FUNC(IsHostSet)(absWork) && absWork->absolutePath) {
+	if (URI_FUNC(HasHost)(absWork) && absWork->absolutePath) {
 		/* Empty segment needed, instead? */
 		if (absWork->pathHead == NULL) {
 			URI_TYPE(PathSegment) * const segment = memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
@@ -203,7 +203,7 @@ static int URI_FUNC(AddBaseUriImpl)(URI_TYPE(Uri) * absDest,
 	/* [06/32]	else */
 				} else {
 	/* [07/32]		if defined(R.authority) then */
-					if (URI_FUNC(IsHostSet)(relSource)) {
+					if (URI_FUNC(HasHost)(relSource)) {
 	/* [08/32]			T.authority = R.authority; */
 						if (!URI_FUNC(CopyAuthority)(absDest, relSource, memory)) {
 							return URI_ERROR_MALLOC;


### PR DESCRIPTION
I need this function for prepending the `/` to the path component when the relevant getter is used (https://github.com/php/php-src/pull/18836/files#diff-04ea97756e1ce310ccfd4d8775089274da9a7ce11af774336dbda793e6642fcbR197):

```
if (uriparser_uri->absolutePath || uriIsHostSetA(uriparser_uri)) {
    smart_str_appendc(&str, '/');
}

...
```
