### PR TITLE
Do not copy .hostData.ipFuture unnecessarily

### DIFF
--- a/src/UriCopy.c
+++ b/src/UriCopy.c
@@ -153,7 +153,10 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
 		*(destUri->hostData.ip6) = *(sourceUri->hostData.ip6);
 	}
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->hostData.ipFuture, &sourceUri->hostData.ipFuture, URI_FALSE, memory) == URI_FALSE) {
+	if (sourceUri->hostData.ipFuture.first != NULL && sourceUri->hostText.first == sourceUri->hostData.ipFuture.first) {
+		destUri->hostData.ipFuture.first = destUri->hostText.first;
+		destUri->hostData.ipFuture.afterLast = destUri->hostText.afterLast;
+	} else if (URI_FUNC(CopyRangeAsNeeded)(&destUri->hostData.ipFuture, &sourceUri->hostData.ipFuture, URI_FALSE, memory) == URI_FALSE) {
 		URI_FUNC(PreventLeakageAfterCopy)(destUri, doneMask, memory);
 		return URI_ERROR_MALLOC;
 	}

--- a/test/copy.cpp
+++ b/test/copy.cpp
@@ -149,7 +149,8 @@ TEST(CopyUriSuite, SuccessIpFuture) {
 
 	ASSERT_TRUE(destUri.hostData.ip4 == NULL);
 	ASSERT_TRUE(destUri.hostData.ip6 == NULL);
-	ASSERT_EQ(0, strncmp(destUri.hostText.first, "v7.host", strlen("v7.host")));
+	ASSERT_TRUE(destUri.hostText.first == destUri.hostData.ipFuture.first);
+	ASSERT_TRUE(destUri.hostText.afterLast == destUri.hostData.ipFuture.afterLast);
 
 	uriFreeUriMembersA(&destUri);
 }


### PR DESCRIPTION
`.hostData.ipFuture` can hold the same range as `.hostText` does, and copying in this case is not necessary. Actually, PHP's tests revealed a memory leak without this fix when the copied and then normalized URI was used.