### PR TITLE
copying: Add missing initial reset to destUri (follow-up to #230)

### DIFF
--- a/src/UriCopy.c
+++ b/src/UriCopy.c
@@ -111,6 +111,8 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
 
 	URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
+	URI_FUNC(ResetUri)(destUri);
+
 	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->scheme, &sourceUri->scheme, URI_FALSE, memory) == URI_FALSE) {
 		return URI_ERROR_MALLOC;
 	}


### PR DESCRIPTION
Follow-up to #230

Without this initial call, cleanup is shaky and e.g. a done mask with `URI_NORMALIZE_HOST` could cause function `PreventLeakage` to read uninitialized memory from `->hostData.ipFuture.first`.

CC @kocsismate @TimWolla