### PR TITLE
doc/Mainpage.txt: Add missing slash in example

### DIFF
--- a/doc/Mainpage.txt
+++ b/doc/Mainpage.txt
@@ -154,7 +154,7 @@
  * 		free(absUri);
  * 		...
  * 	}
- * 	/COMMENT_HACK* absUri is "file:///E:/Documents%20and%20Settings" now *COMMENT_HACK/
+ * 	/COMMENT_HACK* absUri is "file:///E://Documents%20and%20Settings" now *COMMENT_HACK/
  * 	...
  * 	free(absUri);
  * @endcode


### PR DESCRIPTION
Hello,
This minor change adds a missing slash character to the example code block in the [Filenames and URIs](https://uriparser.github.io/doc/api/latest/index.html#filenames) section.
Thank you.