### PR TITLE
src/UriCopy.c: Fix copying URIs with empty components

### DIFF
--- a/src/UriCopy.c
+++ b/src/UriCopy.c
@@ -119,7 +119,7 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
 
 	revertMask |= URI_NORMALIZE_SCHEME;
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->userInfo, &sourceUri->userInfo, URI_FALSE, memory) == URI_FALSE) {
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->userInfo, &sourceUri->userInfo, URI_TRUE, memory) == URI_FALSE) {
 		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
 		return URI_ERROR_MALLOC;
 	}
@@ -163,7 +163,7 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
 		return URI_ERROR_MALLOC;
 	}
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->portText, &sourceUri->portText, URI_FALSE, memory) == URI_FALSE) {
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->portText, &sourceUri->portText, URI_TRUE, memory) == URI_FALSE) {
 		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
 		return URI_ERROR_MALLOC;
 	}
@@ -210,14 +210,14 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
 		}
 	}
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->query, &sourceUri->query, URI_FALSE, memory) == URI_FALSE) {
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->query, &sourceUri->query, URI_TRUE, memory) == URI_FALSE) {
 		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
 		return URI_ERROR_MALLOC;
 	}
 
 	revertMask |= URI_NORMALIZE_QUERY;
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->fragment, &sourceUri->fragment, URI_FALSE, memory) == URI_FALSE) {
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->fragment, &sourceUri->fragment, URI_TRUE, memory) == URI_FALSE) {
 		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
 		return URI_ERROR_MALLOC;
 	}

--- a/test/copy.cpp
+++ b/test/copy.cpp
@@ -154,3 +154,47 @@ TEST(CopyUriSuite, SuccessIpFuture) {
 
 	uriFreeUriMembersA(&destUri);
 }
+
+TEST(CopyUriSuite, SuccessEmptyPort) {
+	UriUriA destUri;
+	testCopyUri(&destUri, "http://example.com:/");
+
+	ASSERT_TRUE(destUri.portText.first != NULL);
+	ASSERT_TRUE(destUri.portText.afterLast != NULL);
+	ASSERT_EQ(destUri.portText.first, destUri.portText.afterLast);
+
+	uriFreeUriMembersA(&destUri);
+}
+
+TEST(CopyUriSuite, SuccessEmptyUserInfo) {
+	UriUriA destUri;
+	testCopyUri(&destUri, "http://@example.com/");
+
+	ASSERT_TRUE(destUri.userInfo.first != NULL);
+	ASSERT_TRUE(destUri.userInfo.afterLast != NULL);
+	ASSERT_EQ(destUri.userInfo.first, destUri.userInfo.afterLast);
+
+	uriFreeUriMembersA(&destUri);
+}
+
+TEST(CopyUriSuite, SuccessEmptyQuery) {
+	UriUriA destUri;
+	testCopyUri(&destUri, "http://example.com/?");
+
+	ASSERT_TRUE(destUri.query.first != NULL);
+	ASSERT_TRUE(destUri.query.afterLast != NULL);
+	ASSERT_EQ(destUri.query.first, destUri.query.afterLast);
+
+	uriFreeUriMembersA(&destUri);
+}
+
+TEST(CopyUriSuite, SuccessEmptyFragment) {
+	UriUriA destUri;
+	testCopyUri(&destUri, "http://example.com/#");
+
+	ASSERT_TRUE(destUri.fragment.first != NULL);
+	ASSERT_TRUE(destUri.fragment.afterLast != NULL);
+	ASSERT_EQ(destUri.fragment.first, destUri.fragment.afterLast);
+
+	uriFreeUriMembersA(&destUri);
+}


### PR DESCRIPTION
When trying to copy a URI with empty userInfo, portText, query, or fragment components, the copying process would perform a zero-byte allocation for the respective component.

Depending on the malloc implementation, this would either return `NULL`, leading to a bogus `URI_ERROR_MALLOC` being returned from the copying process or a valid zero-byte allocation that will not be freed by FreeUriMembers, resulting in a memory leak.