### PR TITLE
src/UriCommon.h: Remove `CopyRangeAsNeeded`'s `useSafe` parameter

### DIFF
--- a/src/UriCommon.c
+++ b/src/UriCommon.c
@@ -137,11 +137,11 @@ UriBool URI_FUNC(CopyRange)(URI_TYPE(TextRange) * destRange,
 
 
 UriBool URI_FUNC(CopyRangeAsNeeded)(URI_TYPE(TextRange) * destRange,
-		const URI_TYPE(TextRange) * sourceRange, UriBool useSafe, UriMemoryManager * memory) {
+		const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory) {
 	if (sourceRange->first == NULL) {
 		destRange->first = NULL;
 		destRange->afterLast = NULL;
-	} else if (sourceRange->first == sourceRange->afterLast && useSafe) {
+	} else if (sourceRange->first == sourceRange->afterLast) {
 		destRange->first = URI_FUNC(SafeToPointTo);
 		destRange->afterLast = URI_FUNC(SafeToPointTo);
 	} else {

--- a/src/UriCommon.h
+++ b/src/UriCommon.h
@@ -85,7 +85,7 @@ int URI_FUNC(CompareRange)(
 UriBool URI_FUNC(CopyRange)(URI_TYPE(TextRange) * destRange,
 		const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory);
 UriBool URI_FUNC(CopyRangeAsNeeded)(URI_TYPE(TextRange) * destRange,
-		const URI_TYPE(TextRange) * sourceRange, UriBool useSafe, UriMemoryManager * memory);
+		const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory);
 
 UriBool URI_FUNC(RemoveDotSegmentsAbsolute)(URI_TYPE(Uri) * uri,
 		UriMemoryManager * memory);

--- a/src/UriCopy.c
+++ b/src/UriCopy.c
@@ -113,20 +113,20 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
 
 	URI_FUNC(ResetUri)(destUri);
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->scheme, &sourceUri->scheme, URI_FALSE, memory) == URI_FALSE) {
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->scheme, &sourceUri->scheme, memory) == URI_FALSE) {
 		return URI_ERROR_MALLOC;
 	}
 
 	revertMask |= URI_NORMALIZE_SCHEME;
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->userInfo, &sourceUri->userInfo, URI_TRUE, memory) == URI_FALSE) {
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->userInfo, &sourceUri->userInfo, memory) == URI_FALSE) {
 		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
 		return URI_ERROR_MALLOC;
 	}
 
 	revertMask |= URI_NORMALIZE_USER_INFO;
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->hostText, &sourceUri->hostText, URI_TRUE, memory) == URI_FALSE) {
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->hostText, &sourceUri->hostText, memory) == URI_FALSE) {
 		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
 		return URI_ERROR_MALLOC;
 	}
@@ -158,12 +158,12 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
 	if (sourceUri->hostData.ipFuture.first != NULL) {
 		destUri->hostData.ipFuture.first = destUri->hostText.first;
 		destUri->hostData.ipFuture.afterLast = destUri->hostText.afterLast;
-	} else if (URI_FUNC(CopyRangeAsNeeded)(&destUri->hostData.ipFuture, &sourceUri->hostData.ipFuture, URI_FALSE, memory) == URI_FALSE) {
+	} else if (URI_FUNC(CopyRangeAsNeeded)(&destUri->hostData.ipFuture, &sourceUri->hostData.ipFuture, memory) == URI_FALSE) {
 		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
 		return URI_ERROR_MALLOC;
 	}
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->portText, &sourceUri->portText, URI_TRUE, memory) == URI_FALSE) {
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->portText, &sourceUri->portText, memory) == URI_FALSE) {
 		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
 		return URI_ERROR_MALLOC;
 	}
@@ -194,7 +194,7 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
 				revertMask |= URI_NORMALIZE_PATH;
 			}
 
-			if (URI_FUNC(CopyRangeAsNeeded)(&destWalker->text, &sourceWalker->text, URI_TRUE, memory) == URI_FALSE) {
+			if (URI_FUNC(CopyRangeAsNeeded)(&destWalker->text, &sourceWalker->text, memory) == URI_FALSE) {
 				URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
 				return URI_ERROR_MALLOC;
 			}
@@ -210,14 +210,14 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
 		}
 	}
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->query, &sourceUri->query, URI_TRUE, memory) == URI_FALSE) {
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->query, &sourceUri->query, memory) == URI_FALSE) {
 		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
 		return URI_ERROR_MALLOC;
 	}
 
 	revertMask |= URI_NORMALIZE_QUERY;
 
-	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->fragment, &sourceUri->fragment, URI_TRUE, memory) == URI_FALSE) {
+	if (URI_FUNC(CopyRangeAsNeeded)(&destUri->fragment, &sourceUri->fragment, memory) == URI_FALSE) {
 		URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
 		return URI_ERROR_MALLOC;
 	}


### PR DESCRIPTION
Since the previous commit 00fd627db26475981fa7470e599c325a0934b900 that fixes a memory leak when copying URIs with empty components, the `useSafe` parameter of the `CopyRangeAsNeeded` function is always either set to `URI_TRUE` or the function is called with a non-empty range, which bypasses the `useSafe` parameter entirely.

Since this parameter is useless, we can remove it entirely, removing a possible footgun from the API.