### PR TITLE
Fix docstring typo in `ParseIpFourAddress`

### DIFF
--- a/include/uriparser/UriIp4.h
+++ b/include/uriparser/UriIp4.h
@@ -88,7 +88,7 @@ extern "C" {
 
 
 /**
- * Converts a IPv4 text representation into four bytes.
+ * Converts an IPv4 text representation into four bytes.
  *
  * @param octetOutput  Output destination
  * @param first        First character of IPv4 text to parse


### PR DESCRIPTION
Extracted from #249 …