### PR TITLE
Add function `BaseRuntimeVersion` + fix `URI_VER*_UNICODE` macros (fixes #219)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,7 @@ set(LIBRARY_CODE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriSetScheme.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriSetUserInfo.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/UriShorten.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/UriVersion.c
 )
 
 add_library(uriparser

--- a/include/uriparser/Uri.h
+++ b/include/uriparser/Uri.h
@@ -2403,6 +2403,30 @@ URI_PUBLIC int URI_FUNC(SetUserInfoMm)(URI_TYPE(Uri) * uri,
 
 
 
+/**
+ * Obtain the base runtime version of uriparser.
+ *
+ * The string returned is based on the compile time version
+ * of uriparser.
+ *
+ * @note Distributors may have applied backports of security
+ *       fixes (potentially with adjusting packaging version but often
+ *       <em>without</em> adjusting runtime version)
+ *       or even fully custom patches. As a result, the version string
+ *       returned serves as nothing more than "based on that version",
+ *       it does not guarantee equivalence to vanilla upstream releases
+ *       or absence of additinal downstream patches.
+ *       It is nothing more than "a hint" and MUST NEVER be used to
+ *       make decisions on in application code at runtime.
+ *
+ * @return Pointer to a read-only zero terminated version string
+ *
+ * @since 0.9.9
+ */
+URI_PUBLIC const URI_CHAR * URI_FUNC(BaseRuntimeVersion)(void);
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/uriparser/UriBase.h
+++ b/include/uriparser/UriBase.h
@@ -48,7 +48,8 @@
 
 
 /* Version helper macro */
-#define URI_ANSI_TO_UNICODE(x) L##x
+#define URI_ANSI_TO_UNICODE_HELPER(x)  L ## x
+#define URI_ANSI_TO_UNICODE(x)         URI_ANSI_TO_UNICODE_HELPER(x)
 
 
 

--- a/src/UriVersion.c
+++ b/src/UriVersion.c
@@ -1,0 +1,87 @@
+/*
+ * uriparser - RFC 3986 URI parsing library
+ *
+ * Copyright (C) 2025, Sebastian Pipping <sebastian@pipping.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source  and binary forms, with or without
+ * modification, are permitted provided  that the following conditions
+ * are met:
+ *
+ *     1. Redistributions  of  source  code   must  retain  the  above
+ *        copyright notice, this list  of conditions and the following
+ *        disclaimer.
+ *
+ *     2. Redistributions  in binary  form  must  reproduce the  above
+ *        copyright notice, this list  of conditions and the following
+ *        disclaimer  in  the  documentation  and/or  other  materials
+ *        provided with the distribution.
+ *
+ *     3. Neither the  name of the  copyright holder nor the  names of
+ *        its contributors may be used  to endorse or promote products
+ *        derived from  this software  without specific  prior written
+ *        permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND  ANY EXPRESS OR IMPLIED WARRANTIES,  INCLUDING, BUT NOT
+ * LIMITED TO,  THE IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS
+ * FOR  A  PARTICULAR  PURPOSE  ARE  DISCLAIMED.  IN  NO  EVENT  SHALL
+ * THE  COPYRIGHT HOLDER  OR CONTRIBUTORS  BE LIABLE  FOR ANY  DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL,  EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA,  OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT  LIABILITY,  OR  TORT (INCLUDING  NEGLIGENCE  OR  OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file UriVersion.c
+ * Implements a runtime version getter.
+ * NOTE: This source file includes itself twice.
+ */
+
+/* What encodings are enabled? */
+#include <uriparser/UriDefsConfig.h>
+#if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+/* Include SELF twice */
+# ifdef URI_ENABLE_ANSI
+#  define URI_PASS_ANSI 1
+#  include "UriVersion.c"
+#  undef URI_PASS_ANSI
+# endif
+# ifdef URI_ENABLE_UNICODE
+#  define URI_PASS_UNICODE 1
+#  include "UriVersion.c"
+#  undef URI_PASS_UNICODE
+# endif
+#else
+# ifdef URI_PASS_ANSI
+#  include <uriparser/UriDefsAnsi.h>
+# else
+#  include <uriparser/UriDefsUnicode.h>
+#  include <wchar.h>
+# endif
+
+
+
+#ifndef URI_DOXYGEN
+# include <uriparser/Uri.h>
+#endif
+
+
+
+const URI_CHAR * URI_FUNC(BaseRuntimeVersion)(void) {
+#if defined(URI_PASS_ANSI)
+	return URI_VER_ANSI;
+#elif defined(URI_PASS_UNICODE)
+	return URI_VER_UNICODE;
+#else
+# error Either URI_PASS_ANSI or URI_PASS_UNICODE must be defined
+#endif
+}
+
+
+
+#endif

--- a/test/VersionSuite.cpp
+++ b/test/VersionSuite.cpp
@@ -24,7 +24,7 @@
 
 
 #include "UriConfig.h"  // for PACKAGE_VERSION
-#include <uriparser/UriBase.h>
+#include <uriparser/Uri.h>
 
 
 TEST(VersionSuite, EnsureVersionDefinesInSync) {
@@ -33,4 +33,10 @@ TEST(VersionSuite, EnsureVersionDefinesInSync) {
 			URI_VER_MAJOR, URI_VER_MINOR, URI_VER_RELEASE, URI_VER_SUFFIX_ANSI);
 	ASSERT_NE(bytes_printed, -1);
 	EXPECT_STREQ(INSIDE_VERSION, PACKAGE_VERSION);
+}
+
+TEST(VersionSuite, EnsureRuntimeVersionAsExpected) {
+	// NOTE: This needs a bump for every release
+	EXPECT_STREQ(uriBaseRuntimeVersionA(),  "0.9.8");
+	EXPECT_STREQ(uriBaseRuntimeVersionW(), L"0.9.8");
 }


### PR DESCRIPTION
Fixes #219

In reaction to https://github.com/uriparser/uriparser/pull/256#issuecomment-3247991741

CC @TimWolla @FromeXo