### PR TITLE
UriCommon.c: Do not remove leading `/./` segment when followed by empty segment

### DIFF
--- a/src/UriCommon.c
+++ b/src/UriCommon.c
@@ -210,12 +210,18 @@ UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri,
 				 * and hence the dot segment is essential to that case and cannot be removed.
 				 */
 				removeSegment = URI_TRUE;
-				if (relative && (walker == uri->pathHead) && (walker->next != NULL)) {
-					const URI_CHAR * ch = walker->next->text.first;
-					for (; ch < walker->next->text.afterLast; ch++) {
-						if (*ch == _UT(':')) {
+				if ((walker == uri->pathHead) && (walker->next != NULL)) {
+					if (relative) {
+						const URI_CHAR * ch = walker->next->text.first;
+						for (; ch < walker->next->text.afterLast; ch++) {
+							if (*ch == _UT(':')) {
+								removeSegment = URI_FALSE;
+								break;
+							}
+						}
+					} else {
+						if (walker->next->text.first == walker->next->text.afterLast) {
 							removeSegment = URI_FALSE;
-							break;
 						}
 					}
 				}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1646,6 +1646,13 @@ TEST(UriSuite, TestNormalizeCrashBug20080224) {
 		uriFreeUriMembersW(&testUri);
 }
 
+TEST(UriSuite, TestNormalizeBug262) {
+	EXPECT_TRUE(testNormalizeSyntaxHelper(
+			L"scheme:/.//foo/bar",
+			L"scheme:/.//foo/bar",
+			URI_NORMALIZE_PATH));
+}
+
 namespace {
 	void testFilenameUriConversionHelper(const wchar_t * filename,
 			const wchar_t * uriString, bool forUnix,


### PR DESCRIPTION
Fixes uriparser/uriparser#262.