### PR TITLE
Improve test coverage by mutation testing

### DIFF
--- a/mull.yml
+++ b/mull.yml
@@ -1,0 +1,2 @@
+excludePaths:
+  - test/*

--- a/src/UriMemory.c
+++ b/src/UriMemory.c
@@ -297,6 +297,7 @@ int uriCompleteMemoryManager(UriMemoryManager * memory,
 
 
 
+/* mull-off */
 int uriTestMemoryManagerEx(UriMemoryManager * memory, UriBool challengeAlignment) {
 	const size_t mallocSize = 7;
 	const size_t callocNmemb = 3;
@@ -491,6 +492,7 @@ int uriTestMemoryManagerEx(UriMemoryManager * memory, UriBool challengeAlignment
 
 	return URI_SUCCESS;
 }
+/* mull-on */
 
 
 

--- a/src/UriMemory.c
+++ b/src/UriMemory.c
@@ -237,7 +237,7 @@ static void * uriDecorateRealloc(UriMemoryManager * memory,
 	prevSize = *((size_t *)((char *)ptr - sizeof(size_t) - URI_MALLOC_PADDING));
 
 	/* Anything to do? */
-	if (size <= prevSize) {
+	if (size <= prevSize) { /* mull-ignore cxx_le_to_lt */
 		return ptr;
 	}
 

--- a/test/SetHostIp6.cpp
+++ b/test/SetHostIp6.cpp
@@ -296,6 +296,18 @@ TEST(SetHostIp6, NonNullValueAppliedNonEmptyPriorNull) {
 	uriFreeUriMembersA(&uri);
 }
 
+TEST(SetHostIp6, MutationTesting) {
+	UriUriA uri = parseWellFormedUri("scheme:");
+	const char * const first = "1:23:456:7890::5.43.219.0";
+	const char * const afterLast = first + strlen(first);
+
+	EXPECT_EQ(uriSetHostIp6A(&uri, first, afterLast), URI_SUCCESS);
+
+	assertUriEqual(&uri, "scheme://[0001:0023:0456:7890:0000:0000:052b:db00]");
+
+	uriFreeUriMembersA(&uri);
+}
+
 TEST(SetHostIp6, NonNullValueAppliedNonEmptyPriorIp4) {
 	UriUriA uri = parseWellFormedUri("//1.2.3.4");
 	const char * const first = "::1";


### PR DESCRIPTION
Using [mull](https://mull.readthedocs.io/en/0.26.0/GettingStarted.html):

```
cmake . -DURIPARSER_BUILD_DOCS=0 -DCMAKE_CXX_FLAGS="-O0 -fpass-plugin=/usr/lib/mull-ir-frontend-18 -g -grecord-command-line -fsanitize=address,undefined" -DCMAKE_C_FLAGS="-O0 -fpass-plugin=/usr/lib/mull-ir-frontend-18 -g -grecord-command-line -fsanitize=address,undefined"
```

Before:

```
[info] Using config uriparser/mull.yml
[warning] Could not find dynamic library: libstdc++.so.6
[warning] Could not find dynamic library: libm.so.6
[warning] Could not find dynamic library: libresolv.so.2
[warning] Could not find dynamic library: libgcc_s.so.1
[warning] Could not find dynamic library: libc.so.6
[info] Warm up run (threads: 1)
       [################################] 1/1. Finished in 45ms
[info] Filter mutants (threads: 1)
       [################################] 1/1. Finished in 0ms
[info] Baseline run (threads: 1)
       [################################] 1/1. Finished in 41ms
[info] Running mutants (threads: 12)
       [################################] 33/33. Finished in 833ms
[info] Survived mutants (7/33):
uriparser/src/UriMemory.c:191:11: warning: Survived: Replaced > with >= [cxx_gt_to_ge]
	if (size > ((size_t)-1) - extraBytes) {
	         ^
uriparser/src/UriMemory.c:209:24: warning: Survived: Replaced + with - [cxx_add_to_sub]
	return (char *)buffer + extraBytes;
	                      ^
uriparser/src/UriParseBase.c:57:33: warning: Survived: Replaced + with - [cxx_add_to_sub]
		output[1] = 16 * hexDigits[0] + hexDigits[1];
		                              ^
uriparser/src/UriParseBase.c:63:33: warning: Survived: Replaced + with - [cxx_add_to_sub]
		output[1] = 16 * hexDigits[1] + hexDigits[2];
		                              ^
uriparser/src/UriParseBase.c:83:25: warning: Survived: Replaced + with - [cxx_add_to_sub]
		return 10 * digits[0] + digits[1];
		                      ^
uriparser/src/UriParseBase.c:87:26: warning: Survived: Replaced + with - [cxx_add_to_sub]
		return 100 * digits[0] + 10 * digits[1] + digits[2];
		                       ^
uriparser/src/UriParseBase.c:87:43: warning: Survived: Replaced + with - [cxx_add_to_sub]
		return 100 * digits[0] + 10 * digits[1] + digits[2];
		                                        ^
[info] Mutation score: 78%
[info] Total execution time: 921ms
[info] Surviving mutants: 7
```

After:

```
[info] Using config uriparser/mull.yml
[warning] Could not find dynamic library: libstdc++.so.6
[warning] Could not find dynamic library: libm.so.6
[warning] Could not find dynamic library: libresolv.so.2
[warning] Could not find dynamic library: libgcc_s.so.1
[warning] Could not find dynamic library: libc.so.6
[info] Warm up run (threads: 1)
       [################################] 1/1. Finished in 46ms
[info] Filter mutants (threads: 1)
       [################################] 1/1. Finished in 0ms
[info] Baseline run (threads: 1)
       [################################] 1/1. Finished in 42ms
[info] Running mutants (threads: 12)
       [################################] 33/33. Finished in 767ms
[info] Survived mutants (2/33):
uriparser/src/UriMemory.c:191:11: warning: Survived: Replaced > with >= [cxx_gt_to_ge]
	if (size > ((size_t)-1) - extraBytes) {
	         ^
uriparser/src/UriMemory.c:209:24: warning: Survived: Replaced + with - [cxx_add_to_sub]
	return (char *)buffer + extraBytes;
	                      ^
[info] Mutation score: 93%
[info] Total execution time: 857ms
[info] Surviving mutants: 2
```