### PR TITLE
src/UriSetHostCommon.c: Do not set `absolutePath` for empty paths when removing host

### DIFF
--- a/src/UriSetHostCommon.c
+++ b/src/UriSetHostCommon.c
@@ -166,7 +166,9 @@ int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri, UriHostType hostType,
     if (first == NULL) {
         /* Yes, but disambiguate as needed */
         if (hadHostBefore == URI_TRUE) {
-            uri->absolutePath = URI_TRUE;
+            if (uri->pathHead != NULL) {
+                uri->absolutePath = URI_TRUE;
+            }
 
             const UriBool success =
                 URI_FUNC(EnsureThatPathIsNotMistakenForHost)(uri, memory);

--- a/test/SetHostAuto.cpp
+++ b/test/SetHostAuto.cpp
@@ -115,6 +115,26 @@ TEST(SetHostAuto, NullValueApplied) {
     uriFreeUriMembersA(&uri);
 }
 
+TEST(SetHostAuto, NullValueAppliedNoPath) {
+    UriUriA uri = parseWellFormedUri("https://example.com");
+
+    EXPECT_EQ(uriSetHostAutoA(&uri, NULL, NULL), URI_SUCCESS);
+
+    assertUriEqual(&uri, "https:");
+
+    uriFreeUriMembersA(&uri);
+}
+
+TEST(SetHostAuto, NullValueAppliedNoPath2) {
+    UriUriA uri = parseWellFormedUri("https://example.com?foo=bar");
+
+    EXPECT_EQ(uriSetHostAutoA(&uri, NULL, NULL), URI_SUCCESS);
+
+    assertUriEqual(&uri, "https:?foo=bar");
+
+    uriFreeUriMembersA(&uri);
+}
+
 TEST(SetHostAuto, NonNullValueAppliedEmpty) {
     UriUriA uri = parseWellFormedUri("scheme://host/path");
     const char * const empty = "";


### PR DESCRIPTION
Fixes uriparser/uriparser#275.