### PR TITLE
`build-and-test.yml`: Address warning on CMake <3.10

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -90,8 +90,8 @@ jobs:
           (
             cd googletest-release-${GTEST_VERSION}/
 
-            # Silence warning "Compatibility with CMake < 2.8.12 will be removed"
-            find -name CMakeLists.txt -print -exec sed 's/cmake_minimum_required.*/cmake_minimum_required(VERSION 3.5.0)/' -i {} \;
+            # Silence warning "Compatibility with CMake < 3.10 will be removed"
+            find -name CMakeLists.txt -print -exec sed 's/cmake_minimum_required.*/cmake_minimum_required(VERSION 3.10.0)/' -i {} \;
 
             cmake \
                 -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
The symptom was:
```
[..]
+ cmake -DBUILD_SHARED_LIBS=ON -DCVF_VERSION=1.8.1 -DCMAKE_INSTALL_PREFIX:PATH=/home/runner/.local/ -DCMAKE_C_COMPILER=clang-21 -DCMAKE_CXX_COMPILER=clang++-21 .
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.
  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
[..]
```