### PR TITLE
[CVE-2026-42371] Fix range-length truncation in `CompareRange`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,7 @@ if(URIPARSER_BUILD_TESTS)
     find_package(GTest 1.8.0 REQUIRED)
 
     add_executable(testrunner
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/CompareRangeLengthWrap.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test/copy.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test/FourSuite.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test/MemoryManagerSuite.cpp

--- a/src/UriCommon.c
+++ b/src/UriCommon.c
@@ -66,6 +66,7 @@
 #  endif
 
 #  include <assert.h>
+#  include <stddef.h>
 
 /*extern*/ const URI_CHAR * const URI_FUNC(SafeToPointTo) = _UT("X");
 /*extern*/ const URI_CHAR * const URI_FUNC(ConstPwd) = _UT(".");
@@ -106,6 +107,8 @@ int URI_FUNC(FreeUriPath)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
 /* Compares two text ranges for equal text content */
 int URI_FUNC(CompareRange)(const URI_TYPE(TextRange) * a, const URI_TYPE(TextRange) * b) {
     int diff;
+    ptrdiff_t lenA;
+    ptrdiff_t lenB;
 
     /* NOTE: Both NULL means equal! */
     if ((a == NULL) || (b == NULL)) {
@@ -117,14 +120,16 @@ int URI_FUNC(CompareRange)(const URI_TYPE(TextRange) * a, const URI_TYPE(TextRan
         return ((a->first == NULL) ? 0 : 1) - ((b->first == NULL) ? 0 : 1);
     }
 
-    diff = ((int)(a->afterLast - a->first) - (int)(b->afterLast - b->first));
-    if (diff > 0) {
+    lenA = a->afterLast - a->first;
+    lenB = b->afterLast - b->first;
+
+    if (lenA > lenB) {
         return 1;
-    } else if (diff < 0) {
+    } else if (lenA < lenB) {
         return -1;
     }
 
-    diff = URI_STRNCMP(a->first, b->first, (a->afterLast - a->first));
+    diff = URI_STRNCMP(a->first, b->first, (size_t)lenA);
 
     if (diff > 0) {
         return 1;

--- a/test/CompareRangeLengthWrap.cpp
+++ b/test/CompareRangeLengthWrap.cpp
@@ -1,0 +1,97 @@
+/*
+ * uriparser - RFC 3986 URI parsing library
+ *
+ * Copyright (C) 2026, Joshua W. Windle <joshua.w.windle@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <uriparser/Uri.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+
+#if !defined(_WIN32)
+#  include <sys/mman.h>  // mmap, mprotect, munmap
+#  include <unistd.h>  // sysconf
+#endif
+
+extern "C" {
+int uriCompareRangeA(const UriTextRangeA * a, const UriTextRangeA * b);
+}
+
+#if !defined(_WIN32) && (UINTPTR_MAX > UINT32_MAX)
+namespace {
+static size_t roundUpToPageSize(size_t value, size_t pageSize) {
+    const size_t remainder = value % pageSize;
+    if (remainder == 0U) {
+        return value;
+    }
+
+    const size_t padding = pageSize - remainder;
+    EXPECT_LE(padding, SIZE_MAX - value);
+    return value + padding;
+}
+
+static size_t queryPageSize() {
+    const long pageSize = sysconf(_SC_PAGESIZE);
+    EXPECT_GT(pageSize, 0);
+    return static_cast<size_t>(pageSize);
+}
+}  // namespace
+
+TEST(UriSuite, TestRangeComparisonDoesNotWrapLengthChecksOn64Bit) {
+    const size_t hugeLen = (static_cast<size_t>(1) << 32) + 10U;
+    const size_t shortLen = 10U;
+    const size_t pageSize = queryPageSize();
+    const size_t hugeMapLen = roundUpToPageSize(hugeLen, pageSize);
+    const size_t shortMapLen = pageSize * 2U;
+
+    // Reserve a huge virtual range, with access disabled by default.
+    char * const hugeBase = static_cast<char *>(
+        mmap(NULL, hugeMapLen, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    ASSERT_NE(hugeBase, MAP_FAILED);
+    // Allow access to the first page (and that only).
+    ASSERT_EQ(0, mprotect(hugeBase, pageSize, PROT_READ | PROT_WRITE));
+    // Fill the readable prefix so the vulnerable implementation reaches
+    // content comparison after truncating the large length.
+    memset(hugeBase, 'a', pageSize);
+
+    char * const shortBase = static_cast<char *>(mmap(
+        NULL, shortMapLen, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    ASSERT_NE(shortBase, MAP_FAILED);
+    // Guard the following page so any over-read beyond shortLen faults.
+    ASSERT_EQ(0, mprotect(shortBase + pageSize, pageSize, PROT_NONE));
+
+    char * const shortStart = shortBase + pageSize - shortLen;
+    memset(shortStart, 'a', shortLen);
+
+    UriTextRangeA hugeRange;
+    hugeRange.first = hugeBase;
+    hugeRange.afterLast = hugeBase + hugeLen;
+
+    UriTextRangeA shortRange;
+    shortRange.first = shortStart;
+    shortRange.afterLast = shortStart + shortLen;
+
+    const int comparison = uriCompareRangeA(&hugeRange, &shortRange);
+
+    EXPECT_EQ(1, comparison);
+
+    EXPECT_EQ(0, munmap(hugeBase, hugeMapLen));
+    EXPECT_EQ(0, munmap(shortBase, shortMapLen));
+}
+#endif


### PR DESCRIPTION
This pull request fixes range-length truncation in CompareRange and adds a dedicated regression test.

The previous implementation converted pointer-difference lengths to int during comparison. On 64-bit platforms, this could truncate large range lengths and allow mismatched ranges to be treated as equal length before reaching content comparison.

The fix compares the full range lengths before content comparison.

The regression test exercises this case directly. I validated that the test crashes on the vulnerable revision and passes with this fix.

This PR contains two commits:
1. the fix
2. the regression test