### PR TITLE
[CVE-2026-44927] Stop truncating `ptrdiff_t` to `int`

### DIFF
--- a/src/UriCommon.c
+++ b/src/UriCommon.c
@@ -67,6 +67,7 @@
 
 #  include <assert.h>
 #  include <stddef.h>
+#  include <stdint.h>  // SIZE_MAX
 
 /*extern*/ const URI_CHAR * const URI_FUNC(SafeToPointTo) = _UT("X");
 /*extern*/ const URI_CHAR * const URI_FUNC(ConstPwd) = _UT(".");
@@ -129,8 +130,11 @@ bool URI_FUNC(RangeEquals)(const URI_TYPE(TextRange) * a, const URI_TYPE(TextRan
 UriBool URI_FUNC(CopyRange)(URI_TYPE(TextRange) * destRange,
                             const URI_TYPE(TextRange) * sourceRange,
                             UriMemoryManager * memory) {
-    const int lenInChars = (int)(sourceRange->afterLast - sourceRange->first);
-    const int lenInBytes = lenInChars * sizeof(URI_CHAR);
+    const size_t lenInChars = sourceRange->afterLast - sourceRange->first;
+    if (lenInChars > SIZE_MAX / sizeof(URI_CHAR)) {  // detect integer overflow
+        return URI_FALSE;
+    }
+    const size_t lenInBytes = lenInChars * sizeof(URI_CHAR);
     URI_CHAR * dup = memory->malloc(memory, lenInBytes);
     if (dup == NULL) {
         return URI_FALSE;

--- a/src/UriCommon.c
+++ b/src/UriCommon.c
@@ -173,7 +173,7 @@ UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
     walker->reserved = NULL; /* Prev pointer */
     do {
         UriBool removeSegment = URI_FALSE;
-        int len = (int)(walker->text.afterLast - walker->text.first);
+        const size_t len = walker->text.afterLast - walker->text.first;
         switch (len) {
         case 1:
             if ((walker->text.first)[0] == _UT('.')) {

--- a/src/UriFile.c
+++ b/src/UriFile.c
@@ -64,6 +64,7 @@
 #  endif
 
 #  include <stddef.h>  // size_t
+#  include <stdint.h>  // SIZE_MAX
 
 static URI_INLINE int URI_FUNC(FilenameToUriString)(const URI_CHAR * filename,
                                                     URI_CHAR * uriString,
@@ -90,6 +91,11 @@ static URI_INLINE int URI_FUNC(FilenameToUriString)(const URI_CHAR * filename,
                                                              : _UT("file:///");
         const size_t prefixLen = URI_STRLEN(prefix);
 
+        // Detect and avoid integer overflow
+        if (prefixLen > SIZE_MAX / sizeof(URI_CHAR)) {
+            return URI_ERROR_OUTPUT_TOO_LARGE;
+        }
+
         /* Copy prefix */
         memcpy(uriString, prefix, prefixLen * sizeof(URI_CHAR));
         output += prefixLen;
@@ -103,7 +109,13 @@ static URI_INLINE int URI_FUNC(FilenameToUriString)(const URI_CHAR * filename,
             if (lastSep + 1 < input) {
                 if (!fromUnix && absolute && (firstSegment == URI_TRUE)) {
                     /* Quick hack to not convert "C:" to "C%3A" */
-                    const int charsToCopy = (int)(input - (lastSep + 1));
+                    const size_t charsToCopy = input - (lastSep + 1);
+
+                    // Detect and avoid integer overflow
+                    if (charsToCopy > SIZE_MAX / sizeof(URI_CHAR)) {
+                        return URI_ERROR_OUTPUT_TOO_LARGE;
+                    }
+
                     memcpy(output, lastSep + 1, charsToCopy * sizeof(URI_CHAR));
                     output += charsToCopy;
                 } else {

--- a/src/UriFile.c
+++ b/src/UriFile.c
@@ -63,7 +63,7 @@
 #    include <uriparser/Uri.h>
 #  endif
 
-#  include <stdlib.h> /* for size_t, avoiding stddef.h for older MSVCs */
+#  include <stddef.h>  // size_t
 
 static URI_INLINE int URI_FUNC(FilenameToUriString)(const URI_CHAR * filename,
                                                     URI_CHAR * uriString,

--- a/src/UriNormalize.c
+++ b/src/UriNormalize.c
@@ -73,6 +73,7 @@
 #  endif
 
 #  include <assert.h>
+#  include <stdint.h>  // SIZE_MAX
 
 static int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri, unsigned int inMask,
                                            unsigned int * outMask,
@@ -254,20 +255,22 @@ URI_FUNC(LowercaseInplaceExceptPercentEncoding)(const URI_CHAR * first,
 static URI_INLINE UriBool URI_FUNC(LowercaseMalloc)(const URI_CHAR ** first,
                                                     const URI_CHAR ** afterLast,
                                                     UriMemoryManager * memory) {
-    int lenInChars;
     const int lowerUpperDiff = (_UT('a') - _UT('A'));
     URI_CHAR * buffer;
-    int i = 0;
+    size_t i = 0;
 
     if ((first == NULL) || (afterLast == NULL) || (*first == NULL)
         || (*afterLast == NULL)) {
         return URI_FALSE;
     }
 
-    lenInChars = (int)(*afterLast - *first);
+    const size_t lenInChars = *afterLast - *first;
     if (lenInChars == 0) {
         return URI_TRUE;
-    } else if (lenInChars < 0) {
+    }
+
+    // Detect and avoid integer overflow
+    if (lenInChars > SIZE_MAX / sizeof(URI_CHAR)) {
         return URI_FALSE;
     }
 

--- a/src/UriNormalize.c
+++ b/src/UriNormalize.c
@@ -298,8 +298,8 @@ URI_FUNC(FixPercentEncodingEngine)(const URI_CHAR * inFirst, const URI_CHAR * in
                                    const URI_CHAR * outFirst,
                                    const URI_CHAR ** outAfterLast) {
     URI_CHAR * write = (URI_CHAR *)outFirst;
-    const int lenInChars = (int)(inAfterLast - inFirst);
-    int i = 0;
+    const size_t lenInChars = inAfterLast - inFirst;
+    size_t i = 0;
 
     /* All but last two */
     for (; i + 2 < lenInChars; i++) {

--- a/src/UriNormalize.c
+++ b/src/UriNormalize.c
@@ -353,7 +353,6 @@ static URI_INLINE void URI_FUNC(FixPercentEncodingInplace)(const URI_CHAR * firs
 static URI_INLINE UriBool URI_FUNC(FixPercentEncodingMalloc)(const URI_CHAR ** first,
                                                              const URI_CHAR ** afterLast,
                                                              UriMemoryManager * memory) {
-    int lenInChars;
     URI_CHAR * buffer;
 
     /* Death checks */
@@ -363,10 +362,13 @@ static URI_INLINE UriBool URI_FUNC(FixPercentEncodingMalloc)(const URI_CHAR ** f
     }
 
     /* Old text length */
-    lenInChars = (int)(*afterLast - *first);
+    const size_t lenInChars = *afterLast - *first;
     if (lenInChars == 0) {
         return URI_TRUE;
-    } else if (lenInChars < 0) {
+    }
+
+    // Detect and avoid integer overflow
+    if (lenInChars > SIZE_MAX / sizeof(URI_CHAR)) {
         return URI_FALSE;
     }
 

--- a/src/UriQuery.c
+++ b/src/UriQuery.c
@@ -67,6 +67,7 @@
 
 #  include <limits.h>
 #  include <stddef.h> /* size_t */
+#  include <stdint.h>  // SIZE_MAX
 
 static int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest,
                                         const URI_TYPE(QueryList) * queryList,
@@ -267,8 +268,8 @@ UriBool URI_FUNC(AppendQueryItem)(URI_TYPE(QueryList) * *prevNext, int * itemCou
                                   const URI_CHAR * valueAfter, UriBool plusToSpace,
                                   UriBreakConversion breakConversion,
                                   UriMemoryManager * memory) {
-    const int keyLen = (int)(keyAfter - keyFirst);
-    const int valueLen = (int)(valueAfter - valueFirst);
+    const size_t keyLen = keyAfter - keyFirst;
+    const size_t valueLen = valueAfter - valueFirst;
     URI_CHAR * key;
     URI_CHAR * value;
 
@@ -284,6 +285,13 @@ UriBool URI_FUNC(AppendQueryItem)(URI_TYPE(QueryList) * *prevNext, int * itemCou
         return URI_FALSE; /* Raises malloc error */
     }
     (*prevNext)->next = NULL;
+
+    // Detect integer overflow
+    if ((keyLen > SIZE_MAX - 1) || (keyLen + 1 > SIZE_MAX / sizeof(URI_CHAR))) {
+        memory->free(memory, *prevNext);
+        *prevNext = NULL;
+        return URI_FALSE;  // Raises malloc error
+    }
 
     /* Fill key */
     key = memory->malloc(memory, (keyLen + 1) * sizeof(URI_CHAR));
@@ -305,6 +313,14 @@ UriBool URI_FUNC(AppendQueryItem)(URI_TYPE(QueryList) * *prevNext, int * itemCou
 
     /* Fill value */
     if (valueFirst != NULL) {
+        // Detect integer overflow
+        if ((valueLen > SIZE_MAX - 1) || (valueLen + 1 > SIZE_MAX / sizeof(URI_CHAR))) {
+            memory->free(memory, key);
+            memory->free(memory, *prevNext);
+            *prevNext = NULL;
+            return URI_FALSE;  // Raises malloc error
+        }
+
         value = memory->malloc(memory, (valueLen + 1) * sizeof(URI_CHAR));
         if (value == NULL) {
             memory->free(memory, key);

--- a/src/UriQuery.c
+++ b/src/UriQuery.c
@@ -255,7 +255,14 @@ int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest, const URI_TYPE(QueryList) * qu
     if (dest != NULL) {
         write[0] = _UT('\0');
         if (charsWritten != NULL) {
-            *charsWritten = (int)(write - dest) + 1; /* .. for terminator */
+            const size_t lenInChars = write - dest;
+
+            // Detect and avoid integer overflow
+            if (lenInChars > INT_MAX - 1) {
+                return URI_ERROR_OUTPUT_TOO_LARGE;
+            }
+
+            *charsWritten = (int)(lenInChars + 1); /* .. for terminator */
         }
     }
 

--- a/src/UriRecompose.c
+++ b/src/UriRecompose.c
@@ -64,6 +64,9 @@
 #    include "UriCommon.h"
 #  endif
 
+#  include <limits.h>  // INT_MAX
+#  include <stdint.h>  // SIZE_MAX
+
 static int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(Uri) * uri,
                                     int maxChars, int * charsWritten,
                                     int * charsRequired);
@@ -116,10 +119,19 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                     /* clang-format off */
     /* [03/19]     append scheme to result; */
                     /* clang-format on */
-                    const int charsToWrite =
-                        (int)(uri->scheme.afterLast - uri->scheme.first);
+                    const size_t charsToWrite = uri->scheme.afterLast - uri->scheme.first;
                     if (dest != NULL) {
-                        if (written + charsToWrite <= maxChars) {
+                        // Detect and avoid integer overflow
+                        if (charsToWrite > (size_t)INT_MAX - written) {
+                            return URI_ERROR_TOSTRING_TOO_LONG;
+                        }
+
+                        if (written + charsToWrite <= (size_t)maxChars) {
+                            // Detect and avoid integer overflow
+                            if (charsToWrite > SIZE_MAX / sizeof(URI_CHAR)) {
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+
                             memcpy(dest + written, uri->scheme.first,
                                    charsToWrite * sizeof(URI_CHAR));
                             written += charsToWrite;
@@ -131,6 +143,11 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                             return URI_ERROR_TOSTRING_TOO_LONG;
                         }
                     } else {
+                        // Detect and avoid integer overflow
+                        if (charsToWrite > (size_t)INT_MAX - *charsRequired) {
+                            return URI_ERROR_TOSTRING_TOO_LONG;
+                        }
+
                         (*charsRequired) += charsToWrite;
                     }
                     /* clang-format off */
@@ -180,10 +197,20 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                     /* clang-format on */
                     /* UserInfo */
                     if (uri->userInfo.first != NULL) {
-                        const int charsToWrite =
-                            (int)(uri->userInfo.afterLast - uri->userInfo.first);
+                        const size_t charsToWrite =
+                            uri->userInfo.afterLast - uri->userInfo.first;
                         if (dest != NULL) {
-                            if (written + charsToWrite <= maxChars) {
+                            // Detect and avoid integer overflow
+                            if (charsToWrite > (size_t)INT_MAX - written) {
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+
+                            if (written + charsToWrite <= (size_t)maxChars) {
+                                // Detect and avoid integer overflow
+                                if (charsToWrite > SIZE_MAX / sizeof(URI_CHAR)) {
+                                    return URI_ERROR_TOSTRING_TOO_LONG;
+                                }
+
                                 memcpy(dest + written, uri->userInfo.first,
                                        charsToWrite * sizeof(URI_CHAR));
                                 written += charsToWrite;
@@ -206,6 +233,13 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                 return URI_ERROR_TOSTRING_TOO_LONG;
                             }
                         } else {
+                            // Detect and avoid integer overflow
+                            if ((charsToWrite > (size_t)INT_MAX - 1)
+                                || (charsToWrite + 1
+                                    > (size_t)INT_MAX - *charsRequired)) {
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+
                             (*charsRequired) += charsToWrite + 1;
                         }
                     }
@@ -334,8 +368,8 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                         }
                     } else if (uri->hostData.ipFuture.first != NULL) {
                         /* IPvFuture */
-                        const int charsToWrite = (int)(uri->hostData.ipFuture.afterLast
-                                                       - uri->hostData.ipFuture.first);
+                        const size_t charsToWrite = uri->hostData.ipFuture.afterLast
+                                                    - uri->hostData.ipFuture.first;
                         if (dest != NULL) {
                             if (written + 1 <= maxChars) {
                                 memcpy(dest + written, _UT("["), 1 * sizeof(URI_CHAR));
@@ -348,7 +382,17 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                 return URI_ERROR_TOSTRING_TOO_LONG;
                             }
 
-                            if (written + charsToWrite <= maxChars) {
+                            // Detect and avoid integer overflow
+                            if (charsToWrite > (size_t)INT_MAX - written) {
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+
+                            if (written + charsToWrite <= (size_t)maxChars) {
+                                // Detect and avoid integer overflow
+                                if (charsToWrite > SIZE_MAX / sizeof(URI_CHAR)) {
+                                    return URI_ERROR_TOSTRING_TOO_LONG;
+                                }
+
                                 memcpy(dest + written, uri->hostData.ipFuture.first,
                                        charsToWrite * sizeof(URI_CHAR));
                                 written += charsToWrite;
@@ -371,14 +415,31 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                 return URI_ERROR_TOSTRING_TOO_LONG;
                             }
                         } else {
+                            // Detect and avoid integer overflow
+                            if ((charsToWrite > (size_t)INT_MAX - 1 - 1)
+                                || (1 + charsToWrite + 1
+                                    > (size_t)INT_MAX - *charsRequired)) {
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+
                             (*charsRequired) += 1 + charsToWrite + 1;
                         }
                     } else if (uri->hostText.first != NULL) {
                         /* Regname */
-                        const int charsToWrite =
-                            (int)(uri->hostText.afterLast - uri->hostText.first);
+                        const size_t charsToWrite =
+                            uri->hostText.afterLast - uri->hostText.first;
                         if (dest != NULL) {
-                            if (written + charsToWrite <= maxChars) {
+                            // Detect and avoid integer overflow
+                            if (charsToWrite > (size_t)INT_MAX - written) {
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+
+                            if (written + charsToWrite <= (size_t)maxChars) {
+                                // Detect and avoid integer overflow
+                                if (charsToWrite > SIZE_MAX / sizeof(URI_CHAR)) {
+                                    return URI_ERROR_TOSTRING_TOO_LONG;
+                                }
+
                                 memcpy(dest + written, uri->hostText.first,
                                        charsToWrite * sizeof(URI_CHAR));
                                 written += charsToWrite;
@@ -390,14 +451,19 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                 return URI_ERROR_TOSTRING_TOO_LONG;
                             }
                         } else {
+                            // Detect and avoid integer overflow
+                            if (charsToWrite > (size_t)INT_MAX - *charsRequired) {
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+
                             (*charsRequired) += charsToWrite;
                         }
                     }
 
                     /* Port */
                     if (uri->portText.first != NULL) {
-                        const int charsToWrite =
-                            (int)(uri->portText.afterLast - uri->portText.first);
+                        const size_t charsToWrite =
+                            uri->portText.afterLast - uri->portText.first;
                         if (dest != NULL) {
                             /* Leading ':' */
                             if (written + 1 <= maxChars) {
@@ -411,8 +477,18 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                 return URI_ERROR_TOSTRING_TOO_LONG;
                             }
 
+                            // Detect and avoid integer overflow
+                            if (charsToWrite > (size_t)INT_MAX - written) {
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+
                             /* Port number */
-                            if (written + charsToWrite <= maxChars) {
+                            if (written + charsToWrite <= (size_t)maxChars) {
+                                // Detect and avoid integer overflow
+                                if (charsToWrite > SIZE_MAX / sizeof(URI_CHAR)) {
+                                    return URI_ERROR_TOSTRING_TOO_LONG;
+                                }
+
                                 memcpy(dest + written, uri->portText.first,
                                        charsToWrite * sizeof(URI_CHAR));
                                 written += charsToWrite;
@@ -424,6 +500,13 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                 return URI_ERROR_TOSTRING_TOO_LONG;
                             }
                         } else {
+                            // Detect and avoid integer overflow
+                            if ((charsToWrite > (size_t)INT_MAX - 1)
+                                || (1 + charsToWrite
+                                    > (size_t)INT_MAX - *charsRequired)) {
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+
                             (*charsRequired) += 1 + charsToWrite;
                         }
                     }
@@ -456,10 +539,20 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                 if (uri->pathHead != NULL) {
                     URI_TYPE(PathSegment) * walker = uri->pathHead;
                     do {
-                        const int charsToWrite =
-                            (int)(walker->text.afterLast - walker->text.first);
+                        const size_t charsToWrite =
+                            walker->text.afterLast - walker->text.first;
                         if (dest != NULL) {
-                            if (written + charsToWrite <= maxChars) {
+                            // Detect and avoid integer overflow
+                            if (charsToWrite > (size_t)INT_MAX - written) {
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+
+                            if (written + charsToWrite <= (size_t)maxChars) {
+                                // Detect and avoid integer overflow
+                                if (charsToWrite > SIZE_MAX / sizeof(URI_CHAR)) {
+                                    return URI_ERROR_TOSTRING_TOO_LONG;
+                                }
+
                                 memcpy(dest + written, walker->text.first,
                                        charsToWrite * sizeof(URI_CHAR));
                                 written += charsToWrite;
@@ -471,6 +564,11 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                 return URI_ERROR_TOSTRING_TOO_LONG;
                             }
                         } else {
+                            // Detect and avoid integer overflow
+                            if (charsToWrite > (size_t)INT_MAX - *charsRequired) {
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+
                             (*charsRequired) += charsToWrite;
                         }
 
@@ -520,10 +618,19 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                     /* clang-format off */
     /* [13/19]     append query to result; */
                     /* clang-format on */
-                    const int charsToWrite =
-                        (int)(uri->query.afterLast - uri->query.first);
+                    const size_t charsToWrite = uri->query.afterLast - uri->query.first;
                     if (dest != NULL) {
-                        if (written + charsToWrite <= maxChars) {
+                        // Detect and avoid integer overflow
+                        if (charsToWrite > (size_t)INT_MAX - written) {
+                            return URI_ERROR_TOSTRING_TOO_LONG;
+                        }
+
+                        if (written + charsToWrite <= (size_t)maxChars) {
+                            // Detect and avoid integer overflow
+                            if (charsToWrite > SIZE_MAX / sizeof(URI_CHAR)) {
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+
                             memcpy(dest + written, uri->query.first,
                                    charsToWrite * sizeof(URI_CHAR));
                             written += charsToWrite;
@@ -535,6 +642,11 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                             return URI_ERROR_TOSTRING_TOO_LONG;
                         }
                     } else {
+                        // Detect and avoid integer overflow
+                        if (charsToWrite > (size_t)INT_MAX - *charsRequired) {
+                            return URI_ERROR_TOSTRING_TOO_LONG;
+                        }
+
                         (*charsRequired) += charsToWrite;
                     }
                     /* clang-format off */
@@ -565,10 +677,20 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                     /* clang-format off */
     /* [17/19]     append fragment to result; */
                     /* clang-format on */
-                    const int charsToWrite =
-                        (int)(uri->fragment.afterLast - uri->fragment.first);
+                    const size_t charsToWrite =
+                        uri->fragment.afterLast - uri->fragment.first;
                     if (dest != NULL) {
-                        if (written + charsToWrite <= maxChars) {
+                        // Detect and avoid integer overflow
+                        if (charsToWrite > (size_t)INT_MAX - written) {
+                            return URI_ERROR_TOSTRING_TOO_LONG;
+                        }
+
+                        if (written + charsToWrite <= (size_t)maxChars) {
+                            // Detect and avoid integer overflow
+                            if (charsToWrite > SIZE_MAX / sizeof(URI_CHAR)) {
+                                return URI_ERROR_TOSTRING_TOO_LONG;
+                            }
+
                             memcpy(dest + written, uri->fragment.first,
                                    charsToWrite * sizeof(URI_CHAR));
                             written += charsToWrite;
@@ -580,6 +702,11 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                             return URI_ERROR_TOSTRING_TOO_LONG;
                         }
                     } else {
+                        // Detect and avoid integer overflow
+                        if (charsToWrite > (size_t)INT_MAX - *charsRequired) {
+                            return URI_ERROR_TOSTRING_TOO_LONG;
+                        }
+
                         (*charsRequired) += charsToWrite;
                     }
                     /* clang-format off */

--- a/tool/uriparse.c
+++ b/tool/uriparse.c
@@ -36,6 +36,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <uriparser/Uri.h>
@@ -55,10 +56,26 @@ WINSOCK_API_LINKAGE const char * WSAAPI inet_ntop(int af, const void * src, char
 #  include <netinet/in.h>
 #endif
 
-#define RANGE(x) (int)((x).afterLast - (x).first), ((x).first)
-
 void usage(void) {
     printf("Usage: uriparse URI [..]\n");
+}
+
+void dumpRange(const char * label, const UriTextRangeA * range) {
+    assert(label != NULL);
+    assert(range != NULL);
+    assert(range->first != NULL);
+
+    const int leftColumnMinWidthChars = 14;
+    const size_t labelLenChars = strlen(label);
+
+    const int gapLenChars =
+        (leftColumnMinWidthChars - /* the colon */ 1 > labelLenChars)
+            ? (int)(leftColumnMinWidthChars - labelLenChars - /* the colon */ 1)
+            : /* minimum gap */ 1;
+
+    fprintf(stdout, "%s:%*s", label, gapLenChars, "");
+    fwrite(range->first, range->afterLast - range->first, 1, stdout);
+    fputc('\n', stdout);
 }
 
 int main(int argc, char * argv[]) {
@@ -88,13 +105,13 @@ int main(int argc, char * argv[]) {
             retval = EXIT_FAILURE;
         } else {
             if (uri.scheme.first) {
-                printf("scheme:       %.*s\n", RANGE(uri.scheme));
+                dumpRange("scheme", &(uri.scheme));
             }
             if (uri.userInfo.first) {
-                printf("userInfo:     %.*s\n", RANGE(uri.userInfo));
+                dumpRange("userInfo", &(uri.userInfo));
             }
             if (uri.hostText.first) {
-                printf("hostText:     %.*s\n", RANGE(uri.hostText));
+                dumpRange("hostText", &(uri.hostText));
             }
             if (uri.hostData.ip4) {
                 inet_ntop(AF_INET, uri.hostData.ip4->data, ipstr, sizeof ipstr);
@@ -105,22 +122,22 @@ int main(int argc, char * argv[]) {
                 printf("hostData.ip6: %s\n", ipstr);
             }
             if (uri.hostData.ipFuture.first) {
-                printf("hostData.ipFuture: %.*s\n", RANGE(uri.hostData.ipFuture));
+                dumpRange("hostData.ipFuture", &(uri.hostData.ipFuture));
             }
             if (uri.portText.first) {
-                printf("portText:     %.*s\n", RANGE(uri.portText));
+                dumpRange("portText", &(uri.portText));
             }
             if (uri.pathHead) {
                 const UriPathSegmentA * p = uri.pathHead;
                 for (; p; p = p->next) {
-                    printf(" .. pathSeg:  %.*s\n", RANGE(p->text));
+                    dumpRange(" .. pathSeg", &(p->text));
                 }
             }
             if (uri.query.first) {
-                printf("query:        %.*s\n", RANGE(uri.query));
+                dumpRange("query", &(uri.query));
             }
             if (uri.fragment.first) {
-                printf("fragment:     %.*s\n", RANGE(uri.fragment));
+                dumpRange("fragment", &(uri.fragment));
             }
             const char * const absolutePathLabel = "absolutePath: ";
             printf("%s%s\n", absolutePathLabel,


### PR DESCRIPTION
CC @iliaal