### PR TITLE
[CVE-2026-44928] Fix `EqualsUri` with regard to `.absolutePath`

### DIFF
--- a/src/UriCompare.c
+++ b/src/UriCompare.c
@@ -76,8 +76,8 @@ UriBool URI_FUNC(EqualsUri)(const URI_TYPE(Uri) * a, const URI_TYPE(Uri) * b) {
         return URI_FALSE;
     }
 
-    /* absolutePath */
-    if ((a->scheme.first == NULL) && (a->absolutePath != b->absolutePath)) {
+    /* absolutePath -- not meaningful for URIs with a host set! */
+    if (!URI_FUNC(HasHost)(a) && (a->absolutePath != b->absolutePath)) {
         return URI_FALSE;
     }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -2106,6 +2106,76 @@ TEST(UriSuite, TestEquals) {
     testEqualsHelper("//host:123");
 }
 
+TEST(UriSuite, TestEqualsAbsolutePathWithSchemeWithHost) {
+    UriUriA uriAbsPathTrue;
+    UriUriA uriAbsPathFalse;
+
+    ASSERT_EQ(uriParseSingleUriA(&uriAbsPathTrue, "scheme://host/path1", NULL),
+              URI_SUCCESS);
+    ASSERT_EQ(uriParseSingleUriA(&uriAbsPathFalse, "scheme://host/path1", NULL),
+              URI_SUCCESS);
+    uriAbsPathTrue.absolutePath = URI_TRUE;  // i.e. produce artificially
+
+    EXPECT_EQ(uriAbsPathTrue.absolutePath, URI_TRUE);  // self-test
+    EXPECT_EQ(uriAbsPathFalse.absolutePath, URI_FALSE);  // self-test
+
+    // NOTE: .absolutePath is ignored for URIs with hosts!
+    EXPECT_EQ(uriEqualsUriA(&uriAbsPathFalse, &uriAbsPathTrue), URI_TRUE);
+
+    uriFreeUriMembersA(&uriAbsPathTrue);
+    uriFreeUriMembersA(&uriAbsPathFalse);
+}
+
+TEST(UriSuite, TestEqualsAbsolutePathWithSchemeWithoutHost) {
+    UriUriA uriAbsPathTrue;
+    UriUriA uriAbsPathFalse;
+
+    ASSERT_EQ(uriParseSingleUriA(&uriAbsPathTrue, "scheme:/path1", NULL), URI_SUCCESS);
+    ASSERT_EQ(uriParseSingleUriA(&uriAbsPathFalse, "scheme:path1", NULL), URI_SUCCESS);
+
+    EXPECT_EQ(uriAbsPathTrue.absolutePath, URI_TRUE);  // self-test
+    EXPECT_EQ(uriAbsPathFalse.absolutePath, URI_FALSE);  // self-test
+
+    EXPECT_EQ(uriEqualsUriA(&uriAbsPathFalse, &uriAbsPathTrue), URI_FALSE);
+
+    uriFreeUriMembersA(&uriAbsPathTrue);
+    uriFreeUriMembersA(&uriAbsPathFalse);
+}
+
+TEST(UriSuite, TestEqualsAbsolutePathWithoutSchemeWithHost) {
+    UriUriA uriAbsPathTrue;
+    UriUriA uriAbsPathFalse;
+
+    ASSERT_EQ(uriParseSingleUriA(&uriAbsPathTrue, "//host/path1", NULL), URI_SUCCESS);
+    ASSERT_EQ(uriParseSingleUriA(&uriAbsPathFalse, "//host/path1", NULL), URI_SUCCESS);
+    uriAbsPathTrue.absolutePath = URI_TRUE;  // i.e. produce artificially
+
+    EXPECT_EQ(uriAbsPathTrue.absolutePath, URI_TRUE);  // self-test
+    EXPECT_EQ(uriAbsPathFalse.absolutePath, URI_FALSE);  // self-test
+
+    // NOTE: .absolutePath is ignored for URIs with hosts!
+    EXPECT_EQ(uriEqualsUriA(&uriAbsPathFalse, &uriAbsPathTrue), URI_TRUE);
+
+    uriFreeUriMembersA(&uriAbsPathTrue);
+    uriFreeUriMembersA(&uriAbsPathFalse);
+}
+
+TEST(UriSuite, TestEqualsAbsolutePathWithoutSchemeWithoutHost) {
+    UriUriA uriAbsPathTrue;
+    UriUriA uriAbsPathFalse;
+
+    ASSERT_EQ(uriParseSingleUriA(&uriAbsPathTrue, "/path1", NULL), URI_SUCCESS);
+    ASSERT_EQ(uriParseSingleUriA(&uriAbsPathFalse, "path1", NULL), URI_SUCCESS);
+
+    EXPECT_EQ(uriAbsPathTrue.absolutePath, URI_TRUE);  // self-test
+    EXPECT_EQ(uriAbsPathFalse.absolutePath, URI_FALSE);  // self-test
+
+    EXPECT_EQ(uriEqualsUriA(&uriAbsPathFalse, &uriAbsPathTrue), URI_FALSE);
+
+    uriFreeUriMembersA(&uriAbsPathTrue);
+    uriFreeUriMembersA(&uriAbsPathFalse);
+}
+
 TEST(UriSuite, TestHostTextTerminationIssue15) {
     UriParserStateA state;
     UriUriA uri;


### PR DESCRIPTION
CC @iliaal