### PR TITLE
Fix multine condition indentation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 ---
 Language:        Cpp
 AccessModifierOffset: -4
-AlignAfterOpenBracket: Align
+AlignAfterOpenBracket: DontAlign
 AlignArrayOfStructures: None
 AlignConsecutiveAssignments:
   Enabled:         false

--- a/.clang-format
+++ b/.clang-format
@@ -132,7 +132,7 @@ ColumnLimit:     90
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
+ContinuationIndentWidth: 8
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat:   false

--- a/fuzz/DissectQueryMallocFuzzer.cpp
+++ b/fuzz/DissectQueryMallocFuzzer.cpp
@@ -31,8 +31,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size) {
     const URI_CHAR * query_end = query_start + query.size();
 
     // Break a query like "a=b&2=3" into key/value pairs.
-    int result = URI_FUNC(DissectQueryMalloc)(&query_list, &item_count, query_start,
-                                              query_end);
+    int result = URI_FUNC(DissectQueryMalloc)(
+            &query_list, &item_count, query_start, query_end);
 
     if (query_list == nullptr || result != URI_SUCCESS || item_count < 0) {
         return 0;

--- a/fuzz/DissectQueryMallocFuzzer.cpp
+++ b/fuzz/DissectQueryMallocFuzzer.cpp
@@ -31,8 +31,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size) {
     const URI_CHAR * query_end = query_start + query.size();
 
     // Break a query like "a=b&2=3" into key/value pairs.
-    int result =
-        URI_FUNC(DissectQueryMalloc)(&query_list, &item_count, query_start, query_end);
+    int result = URI_FUNC(DissectQueryMalloc)(&query_list, &item_count, query_start,
+                                              query_end);
 
     if (query_list == nullptr || result != URI_SUCCESS || item_count < 0) {
         return 0;

--- a/fuzz/ParseFuzzer.cpp
+++ b/fuzz/ParseFuzzer.cpp
@@ -103,7 +103,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size) {
 
     UriHolder uriHolder2;
     if (URI_FUNC(ParseSingleUri)(uriHolder2.get(), uri2.c_str(), nullptr)
-        != URI_SUCCESS) {
+            != URI_SUCCESS) {
         return 0;
     }
 

--- a/include/uriparser/Uri.h
+++ b/include/uriparser/Uri.h
@@ -45,8 +45,8 @@
  */
 
 #if (defined(URI_PASS_ANSI) && !defined(URI_H_ANSI)) \
-    || (defined(URI_PASS_UNICODE) && !defined(URI_H_UNICODE)) \
-    || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+        || (defined(URI_PASS_UNICODE) && !defined(URI_H_UNICODE)) \
+        || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* What encodings are enabled? */
 #  include "UriDefsConfig.h"
 #  if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
@@ -63,8 +63,8 @@
 #    endif
 /* Only one pass for each encoding */
 #  elif (defined(URI_PASS_ANSI) && !defined(URI_H_ANSI) && defined(URI_ENABLE_ANSI)) \
-      || (defined(URI_PASS_UNICODE) && !defined(URI_H_UNICODE) \
-          && defined(URI_ENABLE_UNICODE))
+          || (defined(URI_PASS_UNICODE) && !defined(URI_H_UNICODE) \
+              && defined(URI_ENABLE_UNICODE))
 #    ifdef URI_PASS_ANSI
 #      define URI_H_ANSI 1
 #      include "UriDefsAnsi.h"
@@ -462,8 +462,8 @@ URI_PUBLIC URI_CHAR * URI_FUNC(Escape)(const URI_CHAR * in, URI_CHAR * out,
  * @since 0.5.0
  */
 URI_PUBLIC const URI_CHAR *
-    URI_FUNC(UnescapeInPlaceEx)(URI_CHAR * inout, UriBool plusToSpace,
-                                UriBreakConversion breakConversion);
+        URI_FUNC(UnescapeInPlaceEx)(URI_CHAR * inout, UriBool plusToSpace,
+                                    UriBreakConversion breakConversion);
 
 /**
  * Unescapes percent-encoded groups in a given string.
@@ -888,9 +888,9 @@ URI_PUBLIC int URI_FUNC(ComposeQueryCharsRequired)(const URI_TYPE(QueryList) * q
  * @since 0.7.0
  */
 URI_PUBLIC int
-    URI_FUNC(ComposeQueryCharsRequiredEx)(const URI_TYPE(QueryList) * queryList,
-                                          int * charsRequired, UriBool spaceToPlus,
-                                          UriBool normalizeBreaks);
+        URI_FUNC(ComposeQueryCharsRequiredEx)(const URI_TYPE(QueryList) * queryList,
+                                              int * charsRequired, UriBool spaceToPlus,
+                                              UriBool normalizeBreaks);
 
 /**
  * Converts a query list structure back to a query string.

--- a/include/uriparser/Uri.h
+++ b/include/uriparser/Uri.h
@@ -64,7 +64,7 @@
 /* Only one pass for each encoding */
 #  elif (defined(URI_PASS_ANSI) && !defined(URI_H_ANSI) && defined(URI_ENABLE_ANSI)) \
           || (defined(URI_PASS_UNICODE) && !defined(URI_H_UNICODE) \
-              && defined(URI_ENABLE_UNICODE))
+                  && defined(URI_ENABLE_UNICODE))
 #    ifdef URI_PASS_ANSI
 #      define URI_H_ANSI 1
 #      include "UriDefsAnsi.h"
@@ -218,8 +218,8 @@ URI_PUBLIC UriBool URI_FUNC(HasHost)(const URI_TYPE(Uri) * uri);
  * @see uriIsWellFormedHostIp6A
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(ParseIpSixAddress)(UriIp6 * output, const URI_CHAR * first,
-                                           const URI_CHAR * afterLast);
+URI_PUBLIC int URI_FUNC(ParseIpSixAddress)(
+        UriIp6 * output, const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Converts an IPv6 text representation into 16 bytes.
@@ -236,8 +236,7 @@ URI_PUBLIC int URI_FUNC(ParseIpSixAddress)(UriIp6 * output, const URI_CHAR * fir
  * @since 0.9.9
  */
 URI_PUBLIC int URI_FUNC(ParseIpSixAddressMm)(UriIp6 * output, const URI_CHAR * first,
-                                             const URI_CHAR * afterLast,
-                                             UriMemoryManager * memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Parses a RFC 3986 %URI.
@@ -258,7 +257,7 @@ URI_PUBLIC int URI_FUNC(ParseIpSixAddressMm)(UriIp6 * output, const URI_CHAR * f
  * "Single").
  */
 URI_PUBLIC int URI_FUNC(ParseUriEx)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
-                                    const URI_CHAR * afterLast);
+        const URI_CHAR * afterLast);
 
 /**
  * Parses a RFC 3986 %URI.
@@ -295,8 +294,8 @@ URI_PUBLIC int URI_FUNC(ParseUri)(URI_TYPE(ParserState) * state, const URI_CHAR 
  * @see uriToStringA
  * @since 0.9.0
  */
-URI_PUBLIC int URI_FUNC(ParseSingleUri)(URI_TYPE(Uri) * uri, const URI_CHAR * text,
-                                        const URI_CHAR ** errorPos);
+URI_PUBLIC int URI_FUNC(ParseSingleUri)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * text, const URI_CHAR ** errorPos);
 
 /**
  * Parses a single RFC 3986 %URI.
@@ -319,8 +318,7 @@ URI_PUBLIC int URI_FUNC(ParseSingleUri)(URI_TYPE(Uri) * uri, const URI_CHAR * te
  * @since 0.9.0
  */
 URI_PUBLIC int URI_FUNC(ParseSingleUriEx)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                          const URI_CHAR * afterLast,
-                                          const URI_CHAR ** errorPos);
+        const URI_CHAR * afterLast, const URI_CHAR ** errorPos);
 
 /**
  * Parses a single RFC 3986 %URI.
@@ -343,9 +341,8 @@ URI_PUBLIC int URI_FUNC(ParseSingleUriEx)(URI_TYPE(Uri) * uri, const URI_CHAR * 
  * @since 0.9.0
  */
 URI_PUBLIC int URI_FUNC(ParseSingleUriExMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                            const URI_CHAR * afterLast,
-                                            const URI_CHAR ** errorPos,
-                                            UriMemoryManager * memory);
+        const URI_CHAR * afterLast, const URI_CHAR ** errorPos,
+        UriMemoryManager * memory);
 
 /**
  * Frees all memory associated with the members
@@ -411,8 +408,8 @@ URI_PUBLIC int URI_FUNC(FreeUriMembersMm)(URI_TYPE(Uri) * uri, UriMemoryManager 
  * @since 0.5.2
  */
 URI_PUBLIC URI_CHAR * URI_FUNC(EscapeEx)(const URI_CHAR * inFirst,
-                                         const URI_CHAR * inAfterLast, URI_CHAR * out,
-                                         UriBool spaceToPlus, UriBool normalizeBreaks);
+        const URI_CHAR * inAfterLast, URI_CHAR * out, UriBool spaceToPlus,
+        UriBool normalizeBreaks);
 
 /**
  * Percent-encodes all but unreserved characters from the input string and
@@ -442,7 +439,7 @@ URI_PUBLIC URI_CHAR * URI_FUNC(EscapeEx)(const URI_CHAR * inFirst,
  * @since 0.5.0
  */
 URI_PUBLIC URI_CHAR * URI_FUNC(Escape)(const URI_CHAR * in, URI_CHAR * out,
-                                       UriBool spaceToPlus, UriBool normalizeBreaks);
+        UriBool spaceToPlus, UriBool normalizeBreaks);
 
 /**
  * Unescapes percent-encoded groups in a given string.
@@ -461,9 +458,8 @@ URI_PUBLIC URI_CHAR * URI_FUNC(Escape)(const URI_CHAR * in, URI_CHAR * out,
  * @see uriEscapeExA
  * @since 0.5.0
  */
-URI_PUBLIC const URI_CHAR *
-        URI_FUNC(UnescapeInPlaceEx)(URI_CHAR * inout, UriBool plusToSpace,
-                                    UriBreakConversion breakConversion);
+URI_PUBLIC const URI_CHAR * URI_FUNC(UnescapeInPlaceEx)(
+        URI_CHAR * inout, UriBool plusToSpace, UriBreakConversion breakConversion);
 
 /**
  * Unescapes percent-encoded groups in a given string.
@@ -503,8 +499,7 @@ URI_PUBLIC const URI_CHAR * URI_FUNC(UnescapeInPlace)(URI_CHAR * inout);
  * @since 0.4.0
  */
 URI_PUBLIC int URI_FUNC(AddBaseUri)(URI_TYPE(Uri) * absoluteDest,
-                                    const URI_TYPE(Uri) * relativeSource,
-                                    const URI_TYPE(Uri) * absoluteBase);
+        const URI_TYPE(Uri) * relativeSource, const URI_TYPE(Uri) * absoluteBase);
 
 /**
  * Performs reference resolution as described in
@@ -524,9 +519,8 @@ URI_PUBLIC int URI_FUNC(AddBaseUri)(URI_TYPE(Uri) * absoluteDest,
  * @since 0.8.1
  */
 URI_PUBLIC int URI_FUNC(AddBaseUriEx)(URI_TYPE(Uri) * absoluteDest,
-                                      const URI_TYPE(Uri) * relativeSource,
-                                      const URI_TYPE(Uri) * absoluteBase,
-                                      UriResolutionOptions options);
+        const URI_TYPE(Uri) * relativeSource, const URI_TYPE(Uri) * absoluteBase,
+        UriResolutionOptions options);
 
 /**
  * Performs reference resolution as described in
@@ -548,10 +542,8 @@ URI_PUBLIC int URI_FUNC(AddBaseUriEx)(URI_TYPE(Uri) * absoluteDest,
  * @since 0.9.0
  */
 URI_PUBLIC int URI_FUNC(AddBaseUriExMm)(URI_TYPE(Uri) * absoluteDest,
-                                        const URI_TYPE(Uri) * relativeSource,
-                                        const URI_TYPE(Uri) * absoluteBase,
-                                        UriResolutionOptions options,
-                                        UriMemoryManager * memory);
+        const URI_TYPE(Uri) * relativeSource, const URI_TYPE(Uri) * absoluteBase,
+        UriResolutionOptions options, UriMemoryManager * memory);
 
 /**
  * Tries to make a relative %URI (a reference) from an
@@ -576,9 +568,8 @@ URI_PUBLIC int URI_FUNC(AddBaseUriExMm)(URI_TYPE(Uri) * absoluteDest,
  * @since 0.5.2
  */
 URI_PUBLIC int URI_FUNC(RemoveBaseUri)(URI_TYPE(Uri) * dest,
-                                       const URI_TYPE(Uri) * absoluteSource,
-                                       const URI_TYPE(Uri) * absoluteBase,
-                                       UriBool domainRootMode);
+        const URI_TYPE(Uri) * absoluteSource, const URI_TYPE(Uri) * absoluteBase,
+        UriBool domainRootMode);
 
 /**
  * Tries to make a relative %URI (a reference) from an
@@ -603,10 +594,8 @@ URI_PUBLIC int URI_FUNC(RemoveBaseUri)(URI_TYPE(Uri) * dest,
  * @since 0.9.0
  */
 URI_PUBLIC int URI_FUNC(RemoveBaseUriMm)(URI_TYPE(Uri) * dest,
-                                         const URI_TYPE(Uri) * absoluteSource,
-                                         const URI_TYPE(Uri) * absoluteBase,
-                                         UriBool domainRootMode,
-                                         UriMemoryManager * memory);
+        const URI_TYPE(Uri) * absoluteSource, const URI_TYPE(Uri) * absoluteBase,
+        UriBool domainRootMode, UriMemoryManager * memory);
 
 /**
  * Checks two URIs for equivalence. Comparison is done
@@ -634,8 +623,8 @@ URI_PUBLIC UriBool URI_FUNC(EqualsUri)(const URI_TYPE(Uri) * a, const URI_TYPE(U
  * @see uriToStringA
  * @since 0.5.0
  */
-URI_PUBLIC int URI_FUNC(ToStringCharsRequired)(const URI_TYPE(Uri) * uri,
-                                               int * charsRequired);
+URI_PUBLIC int URI_FUNC(ToStringCharsRequired)(
+        const URI_TYPE(Uri) * uri, int * charsRequired);
 
 /**
  * Converts a %URI structure back to text as described in
@@ -658,8 +647,8 @@ URI_PUBLIC int URI_FUNC(ToStringCharsRequired)(const URI_TYPE(Uri) * uri,
  * @see uriToStringCharsRequiredA
  * @since 0.4.0
  */
-URI_PUBLIC int URI_FUNC(ToString)(URI_CHAR * dest, const URI_TYPE(Uri) * uri,
-                                  int maxChars, int * charsWritten);
+URI_PUBLIC int URI_FUNC(ToString)(
+        URI_CHAR * dest, const URI_TYPE(Uri) * uri, int maxChars, int * charsWritten);
 
 /**
  * Copies a %URI structure.
@@ -673,8 +662,7 @@ URI_PUBLIC int URI_FUNC(ToString)(URI_CHAR * dest, const URI_TYPE(Uri) * uri,
  * @since 0.9.9
  */
 URI_PUBLIC int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
-                                   const URI_TYPE(Uri) * sourceUri,
-                                   UriMemoryManager * memory);
+        const URI_TYPE(Uri) * sourceUri, UriMemoryManager * memory);
 
 /**
  * Copies a %URI structure.
@@ -686,8 +674,8 @@ URI_PUBLIC int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri,
  * @see uriCopyUriMmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(CopyUri)(URI_TYPE(Uri) * destUri,
-                                 const URI_TYPE(Uri) * sourceUri);
+URI_PUBLIC int URI_FUNC(CopyUri)(
+        URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri);
 
 /**
  * Determines the components of a %URI that are not normalized.
@@ -718,8 +706,8 @@ URI_PUBLIC unsigned int URI_FUNC(NormalizeSyntaxMaskRequired)(const URI_TYPE(Uri
  * @see uriNormalizeSyntaxMaskRequiredA
  * @since 0.9.0
  */
-URI_PUBLIC int URI_FUNC(NormalizeSyntaxMaskRequiredEx)(const URI_TYPE(Uri) * uri,
-                                                       unsigned int * outMask);
+URI_PUBLIC int URI_FUNC(NormalizeSyntaxMaskRequiredEx)(
+        const URI_TYPE(Uri) * uri, unsigned int * outMask);
 
 /**
  * Normalizes a %URI using a normalization mask.
@@ -757,8 +745,8 @@ URI_PUBLIC int URI_FUNC(NormalizeSyntaxEx)(URI_TYPE(Uri) * uri, unsigned int mas
  * @see uriNormalizeSyntaxMaskRequiredA
  * @since 0.9.0
  */
-URI_PUBLIC int URI_FUNC(NormalizeSyntaxExMm)(URI_TYPE(Uri) * uri, unsigned int mask,
-                                             UriMemoryManager * memory);
+URI_PUBLIC int URI_FUNC(NormalizeSyntaxExMm)(
+        URI_TYPE(Uri) * uri, unsigned int mask, UriMemoryManager * memory);
 
 /**
  * Normalizes all components of a %URI.
@@ -795,8 +783,8 @@ URI_PUBLIC int URI_FUNC(NormalizeSyntax)(URI_TYPE(Uri) * uri);
  * @see uriWindowsFilenameToUriStringA
  * @since 0.5.2
  */
-URI_PUBLIC int URI_FUNC(UnixFilenameToUriString)(const URI_CHAR * filename,
-                                                 URI_CHAR * uriString);
+URI_PUBLIC int URI_FUNC(UnixFilenameToUriString)(
+        const URI_CHAR * filename, URI_CHAR * uriString);
 
 /**
  * Converts a Windows filename to a %URI string.
@@ -816,8 +804,8 @@ URI_PUBLIC int URI_FUNC(UnixFilenameToUriString)(const URI_CHAR * filename,
  * @see uriUnixFilenameToUriStringA
  * @since 0.5.2
  */
-URI_PUBLIC int URI_FUNC(WindowsFilenameToUriString)(const URI_CHAR * filename,
-                                                    URI_CHAR * uriString);
+URI_PUBLIC int URI_FUNC(WindowsFilenameToUriString)(
+        const URI_CHAR * filename, URI_CHAR * uriString);
 
 /**
  * Extracts a Unix filename from a %URI string.
@@ -833,8 +821,8 @@ URI_PUBLIC int URI_FUNC(WindowsFilenameToUriString)(const URI_CHAR * filename,
  * @see uriUriStringToWindowsFilenameA
  * @since 0.5.2
  */
-URI_PUBLIC int URI_FUNC(UriStringToUnixFilename)(const URI_CHAR * uriString,
-                                                 URI_CHAR * filename);
+URI_PUBLIC int URI_FUNC(UriStringToUnixFilename)(
+        const URI_CHAR * uriString, URI_CHAR * filename);
 
 /**
  * Extracts a Windows filename from a %URI string.
@@ -850,8 +838,8 @@ URI_PUBLIC int URI_FUNC(UriStringToUnixFilename)(const URI_CHAR * uriString,
  * @see uriUriStringToUnixFilenameA
  * @since 0.5.2
  */
-URI_PUBLIC int URI_FUNC(UriStringToWindowsFilename)(const URI_CHAR * uriString,
-                                                    URI_CHAR * filename);
+URI_PUBLIC int URI_FUNC(UriStringToWindowsFilename)(
+        const URI_CHAR * uriString, URI_CHAR * filename);
 
 /**
  * Calculates the number of characters needed to store the
@@ -868,8 +856,8 @@ URI_PUBLIC int URI_FUNC(UriStringToWindowsFilename)(const URI_CHAR * uriString,
  * @see uriComposeQueryA
  * @since 0.7.0
  */
-URI_PUBLIC int URI_FUNC(ComposeQueryCharsRequired)(const URI_TYPE(QueryList) * queryList,
-                                                   int * charsRequired);
+URI_PUBLIC int URI_FUNC(ComposeQueryCharsRequired)(
+        const URI_TYPE(QueryList) * queryList, int * charsRequired);
 
 /**
  * Calculates the number of characters needed to store the
@@ -887,10 +875,9 @@ URI_PUBLIC int URI_FUNC(ComposeQueryCharsRequired)(const URI_TYPE(QueryList) * q
  * @see uriComposeQueryExA
  * @since 0.7.0
  */
-URI_PUBLIC int
-        URI_FUNC(ComposeQueryCharsRequiredEx)(const URI_TYPE(QueryList) * queryList,
-                                              int * charsRequired, UriBool spaceToPlus,
-                                              UriBool normalizeBreaks);
+URI_PUBLIC int URI_FUNC(ComposeQueryCharsRequiredEx)(
+        const URI_TYPE(QueryList) * queryList, int * charsRequired, UriBool spaceToPlus,
+        UriBool normalizeBreaks);
 
 /**
  * Converts a query list structure back to a query string.
@@ -917,8 +904,7 @@ URI_PUBLIC int
  * @since 0.7.0
  */
 URI_PUBLIC int URI_FUNC(ComposeQuery)(URI_CHAR * dest,
-                                      const URI_TYPE(QueryList) * queryList, int maxChars,
-                                      int * charsWritten);
+        const URI_TYPE(QueryList) * queryList, int maxChars, int * charsWritten);
 
 /**
  * Converts a query list structure back to a query string.
@@ -945,9 +931,8 @@ URI_PUBLIC int URI_FUNC(ComposeQuery)(URI_CHAR * dest,
  * @since 0.7.0
  */
 URI_PUBLIC int URI_FUNC(ComposeQueryEx)(URI_CHAR * dest,
-                                        const URI_TYPE(QueryList) * queryList,
-                                        int maxChars, int * charsWritten,
-                                        UriBool spaceToPlus, UriBool normalizeBreaks);
+        const URI_TYPE(QueryList) * queryList, int maxChars, int * charsWritten,
+        UriBool spaceToPlus, UriBool normalizeBreaks);
 
 /**
  * Converts a query list structure back to a query string.
@@ -969,8 +954,8 @@ URI_PUBLIC int URI_FUNC(ComposeQueryEx)(URI_CHAR * dest,
  * @see uriDissectQueryMallocExMmA
  * @since 0.7.0
  */
-URI_PUBLIC int URI_FUNC(ComposeQueryMalloc)(URI_CHAR ** dest,
-                                            const URI_TYPE(QueryList) * queryList);
+URI_PUBLIC int URI_FUNC(ComposeQueryMalloc)(
+        URI_CHAR ** dest, const URI_TYPE(QueryList) * queryList);
 
 /**
  * Converts a query list structure back to a query string.
@@ -993,9 +978,8 @@ URI_PUBLIC int URI_FUNC(ComposeQueryMalloc)(URI_CHAR ** dest,
  * @since 0.7.0
  */
 URI_PUBLIC int URI_FUNC(ComposeQueryMallocEx)(URI_CHAR ** dest,
-                                              const URI_TYPE(QueryList) * queryList,
-                                              UriBool spaceToPlus,
-                                              UriBool normalizeBreaks);
+        const URI_TYPE(QueryList) * queryList, UriBool spaceToPlus,
+        UriBool normalizeBreaks);
 
 /**
  * Converts a query list structure back to a query string.
@@ -1018,10 +1002,8 @@ URI_PUBLIC int URI_FUNC(ComposeQueryMallocEx)(URI_CHAR ** dest,
  * @since 0.9.0
  */
 URI_PUBLIC int URI_FUNC(ComposeQueryMallocExMm)(URI_CHAR ** dest,
-                                                const URI_TYPE(QueryList) * queryList,
-                                                UriBool spaceToPlus,
-                                                UriBool normalizeBreaks,
-                                                UriMemoryManager * memory);
+        const URI_TYPE(QueryList) * queryList, UriBool spaceToPlus,
+        UriBool normalizeBreaks, UriMemoryManager * memory);
 
 /**
  * Constructs a query list from the raw query string of a given URI.
@@ -1042,8 +1024,7 @@ URI_PUBLIC int URI_FUNC(ComposeQueryMallocExMm)(URI_CHAR ** dest,
  * @since 0.7.0
  */
 URI_PUBLIC int URI_FUNC(DissectQueryMalloc)(URI_TYPE(QueryList) * *dest, int * itemCount,
-                                            const URI_CHAR * first,
-                                            const URI_CHAR * afterLast);
+        const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Constructs a query list from the raw query string of a given URI.
@@ -1064,10 +1045,8 @@ URI_PUBLIC int URI_FUNC(DissectQueryMalloc)(URI_TYPE(QueryList) * *dest, int * i
  * @since 0.7.0
  */
 URI_PUBLIC int URI_FUNC(DissectQueryMallocEx)(URI_TYPE(QueryList) * *dest,
-                                              int * itemCount, const URI_CHAR * first,
-                                              const URI_CHAR * afterLast,
-                                              UriBool plusToSpace,
-                                              UriBreakConversion breakConversion);
+        int * itemCount, const URI_CHAR * first, const URI_CHAR * afterLast,
+        UriBool plusToSpace, UriBreakConversion breakConversion);
 
 /**
  * Constructs a query list from the raw query string of a given URI.
@@ -1089,11 +1068,9 @@ URI_PUBLIC int URI_FUNC(DissectQueryMallocEx)(URI_TYPE(QueryList) * *dest,
  * @since 0.9.0
  */
 URI_PUBLIC int URI_FUNC(DissectQueryMallocExMm)(URI_TYPE(QueryList) * *dest,
-                                                int * itemCount, const URI_CHAR * first,
-                                                const URI_CHAR * afterLast,
-                                                UriBool plusToSpace,
-                                                UriBreakConversion breakConversion,
-                                                UriMemoryManager * memory);
+        int * itemCount, const URI_CHAR * first, const URI_CHAR * afterLast,
+        UriBool plusToSpace, UriBreakConversion breakConversion,
+        UriMemoryManager * memory);
 
 /**
  * Frees all memory associated with the given query list.
@@ -1117,8 +1094,8 @@ URI_PUBLIC void URI_FUNC(FreeQueryList)(URI_TYPE(QueryList) * queryList);
  * @see uriFreeQueryListA
  * @since 0.9.0
  */
-URI_PUBLIC int URI_FUNC(FreeQueryListMm)(URI_TYPE(QueryList) * queryList,
-                                         UriMemoryManager * memory);
+URI_PUBLIC int URI_FUNC(FreeQueryListMm)(
+        URI_TYPE(QueryList) * queryList, UriMemoryManager * memory);
 
 /**
  * Makes the %URI hold copies of strings so that it no longer depends
@@ -1171,8 +1148,8 @@ URI_PUBLIC int URI_FUNC(MakeOwnerMm)(URI_TYPE(Uri) * uri, UriMemoryManager * mem
  * @see uriSetFragmentMmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedFragment)(const URI_CHAR * first,
-                                                  const URI_CHAR * afterLast);
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedFragment)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed IPv4 address
@@ -1196,8 +1173,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedFragment)(const URI_CHAR * first,
  * @see uriSetHostIp4MmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedHostIp4)(const URI_CHAR * first,
-                                                 const URI_CHAR * afterLast);
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedHostIp4)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed IPv6 address
@@ -1248,8 +1225,8 @@ int URI_FUNC(IsWellFormedHostIp6)(const URI_CHAR * first, const URI_CHAR * after
  * @see uriIsWellFormedUserInfoA
  * @since 0.9.9
  */
-int URI_FUNC(IsWellFormedHostIp6Mm)(const URI_CHAR * first, const URI_CHAR * afterLast,
-                                    UriMemoryManager * memory);
+int URI_FUNC(IsWellFormedHostIp6Mm)(
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Determines if the given text range contains a well-formed IPvFuture address
@@ -1276,8 +1253,8 @@ int URI_FUNC(IsWellFormedHostIp6Mm)(const URI_CHAR * first, const URI_CHAR * aft
  * @see uriSetHostIpFutureMmA
  * @since 0.9.9
  */
-int URI_FUNC(IsWellFormedHostIpFuture)(const URI_CHAR * first,
-                                       const URI_CHAR * afterLast);
+int URI_FUNC(IsWellFormedHostIpFuture)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed IPvFuture address
@@ -1303,9 +1280,8 @@ int URI_FUNC(IsWellFormedHostIpFuture)(const URI_CHAR * first,
  * @see uriSetHostIpFutureMmA
  * @since 0.9.9
  */
-int URI_FUNC(IsWellFormedHostIpFutureMm)(const URI_CHAR * first,
-                                         const URI_CHAR * afterLast,
-                                         UriMemoryManager * memory);
+int URI_FUNC(IsWellFormedHostIpFutureMm)(
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Determines if the given text range contains a well-formed registered host name
@@ -1329,8 +1305,8 @@ int URI_FUNC(IsWellFormedHostIpFutureMm)(const URI_CHAR * first,
  * @see uriSetHostRegNameMmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedHostRegName)(const URI_CHAR * first,
-                                                     const URI_CHAR * afterLast);
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedHostRegName)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed path
@@ -1357,9 +1333,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedHostRegName)(const URI_CHAR * first,
  * @see uriSetPathMmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedPath)(const URI_CHAR * first,
-                                              const URI_CHAR * afterLast,
-                                              UriBool hasHost);
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedPath)(
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriBool hasHost);
 
 /**
  * Determines if the given text range contains a well-formed port text
@@ -1383,8 +1358,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedPath)(const URI_CHAR * first,
  * @see uriSetPortTextMmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedPort)(const URI_CHAR * first,
-                                              const URI_CHAR * afterLast);
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedPort)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed query
@@ -1408,8 +1383,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedPort)(const URI_CHAR * first,
  * @see uriSetQueryMmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedQuery)(const URI_CHAR * first,
-                                               const URI_CHAR * afterLast);
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedQuery)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed scheme
@@ -1434,8 +1409,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedQuery)(const URI_CHAR * first,
  * @see uriSetSchemeMmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedScheme)(const URI_CHAR * first,
-                                                const URI_CHAR * afterLast);
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedScheme)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed user info
@@ -1459,8 +1434,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedScheme)(const URI_CHAR * first,
  * @see uriSetUserInfoMmA
  * @since 0.9.9
  */
-URI_PUBLIC UriBool URI_FUNC(IsWellFormedUserInfo)(const URI_CHAR * first,
-                                                  const URI_CHAR * afterLast);
+URI_PUBLIC UriBool URI_FUNC(IsWellFormedUserInfo)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Sets the fragment of the given %URI to the given value.
@@ -1495,8 +1470,8 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedUserInfo)(const URI_CHAR * first,
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetFragment)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                     const URI_CHAR * afterLast);
+URI_PUBLIC int URI_FUNC(SetFragment)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Sets the fragment of the given %URI to the given value.
@@ -1531,8 +1506,7 @@ URI_PUBLIC int URI_FUNC(SetFragment)(URI_TYPE(Uri) * uri, const URI_CHAR * first
  * @since 0.9.9
  */
 URI_PUBLIC int URI_FUNC(SetFragmentMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                       const URI_CHAR * afterLast,
-                                       UriMemoryManager * memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1572,8 +1546,8 @@ URI_PUBLIC int URI_FUNC(SetFragmentMm)(URI_TYPE(Uri) * uri, const URI_CHAR * fir
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostAuto)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                     const URI_CHAR * afterLast);
+URI_PUBLIC int URI_FUNC(SetHostAuto)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1613,8 +1587,7 @@ URI_PUBLIC int URI_FUNC(SetHostAuto)(URI_TYPE(Uri) * uri, const URI_CHAR * first
  * @since 0.9.9
  */
 URI_PUBLIC int URI_FUNC(SetHostAutoMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                       const URI_CHAR * afterLast,
-                                       UriMemoryManager * memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1649,8 +1622,8 @@ URI_PUBLIC int URI_FUNC(SetHostAutoMm)(URI_TYPE(Uri) * uri, const URI_CHAR * fir
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostRegName)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                        const URI_CHAR * afterLast);
+URI_PUBLIC int URI_FUNC(SetHostRegName)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1685,8 +1658,7 @@ URI_PUBLIC int URI_FUNC(SetHostRegName)(URI_TYPE(Uri) * uri, const URI_CHAR * fi
  * @since 0.9.9
  */
 URI_PUBLIC int URI_FUNC(SetHostRegNameMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                          const URI_CHAR * afterLast,
-                                          UriMemoryManager * memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1721,8 +1693,8 @@ URI_PUBLIC int URI_FUNC(SetHostRegNameMm)(URI_TYPE(Uri) * uri, const URI_CHAR * 
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostIp4)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                    const URI_CHAR * afterLast);
+URI_PUBLIC int URI_FUNC(SetHostIp4)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1757,8 +1729,7 @@ URI_PUBLIC int URI_FUNC(SetHostIp4)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
  * @since 0.9.9
  */
 URI_PUBLIC int URI_FUNC(SetHostIp4Mm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                      const URI_CHAR * afterLast,
-                                      UriMemoryManager * memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1793,8 +1764,8 @@ URI_PUBLIC int URI_FUNC(SetHostIp4Mm)(URI_TYPE(Uri) * uri, const URI_CHAR * firs
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostIp6)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                    const URI_CHAR * afterLast);
+URI_PUBLIC int URI_FUNC(SetHostIp6)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1829,8 +1800,7 @@ URI_PUBLIC int URI_FUNC(SetHostIp6)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
  * @since 0.9.9
  */
 URI_PUBLIC int URI_FUNC(SetHostIp6Mm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                      const URI_CHAR * afterLast,
-                                      UriMemoryManager * memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1865,8 +1835,8 @@ URI_PUBLIC int URI_FUNC(SetHostIp6Mm)(URI_TYPE(Uri) * uri, const URI_CHAR * firs
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetHostIpFuture)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                         const URI_CHAR * afterLast);
+URI_PUBLIC int URI_FUNC(SetHostIpFuture)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Sets the host of the given %URI to the given value.
@@ -1901,8 +1871,7 @@ URI_PUBLIC int URI_FUNC(SetHostIpFuture)(URI_TYPE(Uri) * uri, const URI_CHAR * f
  * @since 0.9.9
  */
 URI_PUBLIC int URI_FUNC(SetHostIpFutureMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                           const URI_CHAR * afterLast,
-                                           UriMemoryManager * memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Sets the path of the given %URI to the given value.
@@ -1940,8 +1909,8 @@ URI_PUBLIC int URI_FUNC(SetHostIpFutureMm)(URI_TYPE(Uri) * uri, const URI_CHAR *
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetPath)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                 const URI_CHAR * afterLast);
+URI_PUBLIC int URI_FUNC(SetPath)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Sets the path of the given %URI to the given value.
@@ -1981,7 +1950,7 @@ URI_PUBLIC int URI_FUNC(SetPath)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
  * @since 0.9.9
  */
 URI_PUBLIC int URI_FUNC(SetPathMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                   const URI_CHAR * afterLast, UriMemoryManager * memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Sets the port text of the given %URI to the given value.
@@ -2018,8 +1987,8 @@ URI_PUBLIC int URI_FUNC(SetPathMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetPortText)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                     const URI_CHAR * afterLast);
+URI_PUBLIC int URI_FUNC(SetPortText)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Sets the port text of the given %URI to the given value.
@@ -2056,8 +2025,7 @@ URI_PUBLIC int URI_FUNC(SetPortText)(URI_TYPE(Uri) * uri, const URI_CHAR * first
  * @since 0.9.9
  */
 URI_PUBLIC int URI_FUNC(SetPortTextMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                       const URI_CHAR * afterLast,
-                                       UriMemoryManager * memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Sets the query of the given %URI to the given value.
@@ -2092,8 +2060,8 @@ URI_PUBLIC int URI_FUNC(SetPortTextMm)(URI_TYPE(Uri) * uri, const URI_CHAR * fir
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetQuery)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                  const URI_CHAR * afterLast);
+URI_PUBLIC int URI_FUNC(SetQuery)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Sets the query of the given %URI to the given value.
@@ -2128,8 +2096,7 @@ URI_PUBLIC int URI_FUNC(SetQuery)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
  * @since 0.9.9
  */
 URI_PUBLIC int URI_FUNC(SetQueryMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                    const URI_CHAR * afterLast,
-                                    UriMemoryManager * memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Sets the scheme of the given %URI to the given value.
@@ -2164,8 +2131,8 @@ URI_PUBLIC int URI_FUNC(SetQueryMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
  * @see uriSetUserInfoA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetScheme)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                   const URI_CHAR * afterLast);
+URI_PUBLIC int URI_FUNC(SetScheme)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Sets the scheme of the given %URI to the given value.
@@ -2200,8 +2167,7 @@ URI_PUBLIC int URI_FUNC(SetScheme)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
  * @since 0.9.9
  */
 URI_PUBLIC int URI_FUNC(SetSchemeMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                     const URI_CHAR * afterLast,
-                                     UriMemoryManager * memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Sets the user info of the given %URI to the given value.
@@ -2238,8 +2204,8 @@ URI_PUBLIC int URI_FUNC(SetSchemeMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first
  * @see uriSetUserInfoMmA
  * @since 0.9.9
  */
-URI_PUBLIC int URI_FUNC(SetUserInfo)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                     const URI_CHAR * afterLast);
+URI_PUBLIC int URI_FUNC(SetUserInfo)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Sets the user info of the given %URI to the given value.
@@ -2276,8 +2242,7 @@ URI_PUBLIC int URI_FUNC(SetUserInfo)(URI_TYPE(Uri) * uri, const URI_CHAR * first
  * @since 0.9.9
  */
 URI_PUBLIC int URI_FUNC(SetUserInfoMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                       const URI_CHAR * afterLast,
-                                       UriMemoryManager * memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
  * Obtain the base runtime version of uriparser.

--- a/include/uriparser/UriBase.h
+++ b/include/uriparser/UriBase.h
@@ -227,8 +227,8 @@ typedef struct UriMemoryManagerStruct {
     UriFuncReallocarray reallocarray; /**< Pointer to custom reallocarray(3); to emulate
                                          using realloc see uriEmulateReallocarray */
     UriFuncFree free; /**< Pointer to custom free(3) */
-    void *
-        userData; /**< Pointer to data that the other function members need access to */
+    void * userData; /**< Pointer to data that the other function members need access to
+                      */
 } UriMemoryManager; /**< @copydoc UriMemoryManagerStruct */
 
 /**
@@ -240,7 +240,7 @@ typedef enum UriBreakConversionEnum {
     URI_BR_TO_CR, /**< Convert to Macintosh line breaks ("\\x0d") */
     URI_BR_TO_UNIX = URI_BR_TO_LF, /**< @copydoc UriBreakConversionEnum::URI_BR_TO_LF */
     URI_BR_TO_WINDOWS =
-        URI_BR_TO_CRLF, /**< @copydoc UriBreakConversionEnum::URI_BR_TO_CRLF */
+            URI_BR_TO_CRLF, /**< @copydoc UriBreakConversionEnum::URI_BR_TO_CRLF */
     URI_BR_TO_MAC = URI_BR_TO_CR, /**< @copydoc UriBreakConversionEnum::URI_BR_TO_CR */
     URI_BR_DONT_TOUCH /**< Copy line breaks unmodified */
 } UriBreakConversion; /**< @copydoc UriBreakConversionEnum */
@@ -252,14 +252,14 @@ typedef enum UriNormalizationMaskEnum {
     URI_NORMALIZED = 0, /**< Do not normalize anything */
     URI_NORMALIZE_SCHEME = 1 << 0, /**< Normalize scheme (fix uppercase letters) */
     URI_NORMALIZE_USER_INFO =
-        1 << 1, /**< Normalize user info (fix uppercase percent-encodings) */
+            1 << 1, /**< Normalize user info (fix uppercase percent-encodings) */
     URI_NORMALIZE_HOST = 1 << 2, /**< Normalize host (fix uppercase letters) */
     URI_NORMALIZE_PATH = 1 << 3, /**< Normalize path (fix uppercase percent-encodings and
                                     redundant dot segments) */
     URI_NORMALIZE_QUERY =
-        1 << 4, /**< Normalize query (fix uppercase percent-encodings) */
+            1 << 4, /**< Normalize query (fix uppercase percent-encodings) */
     URI_NORMALIZE_FRAGMENT =
-        1 << 5, /**< Normalize fragment (fix uppercase percent-encodings) */
+            1 << 5, /**< Normalize fragment (fix uppercase percent-encodings) */
     URI_NORMALIZE_PORT = 1 << 6 /**< Normalize port (drop leading zeros) @since 0.9.9 */
 } UriNormalizationMask; /**< @copydoc UriNormalizationMaskEnum */
 
@@ -269,7 +269,7 @@ typedef enum UriNormalizationMaskEnum {
 typedef enum UriResolutionOptionsEnum {
     URI_RESOLVE_STRICTLY = 0, /**< Full RFC conformance */
     URI_RESOLVE_IDENTICAL_SCHEME_COMPAT =
-        1 << 0 /**< Treat %URI to resolve with identical scheme as having no scheme */
+            1 << 0 /**< Treat %URI to resolve with identical scheme as having no scheme */
 } UriResolutionOptions; /**< @copydoc UriResolutionOptionsEnum */
 
 /**

--- a/include/uriparser/UriBase.h
+++ b/include/uriparser/UriBase.h
@@ -71,11 +71,11 @@
 
 /* Full version strings */
 #  define URI_VER_ANSI \
-      URI_VER_ANSI_HELPER(URI_VER_MAJOR, URI_VER_MINOR, URI_VER_RELEASE, \
-                          URI_VER_SUFFIX_ANSI)
+      URI_VER_ANSI_HELPER( \
+              URI_VER_MAJOR, URI_VER_MINOR, URI_VER_RELEASE, URI_VER_SUFFIX_ANSI)
 #  define URI_VER_UNICODE \
-      URI_VER_UNICODE_HELPER(URI_VER_MAJOR, URI_VER_MINOR, URI_VER_RELEASE, \
-                             URI_VER_SUFFIX_UNICODE)
+      URI_VER_UNICODE_HELPER( \
+              URI_VER_MAJOR, URI_VER_MINOR, URI_VER_RELEASE, URI_VER_SUFFIX_UNICODE)
 
 /* Unused parameter macro */
 #  ifdef __GNUC__
@@ -200,8 +200,8 @@ typedef void * (*UriFuncRealloc)(struct UriMemoryManagerStruct *, void *, size_t
  *
  * @since 0.9.0
  */
-typedef void * (*UriFuncReallocarray)(struct UriMemoryManagerStruct *, void *, size_t,
-                                      size_t);
+typedef void * (*UriFuncReallocarray)(
+        struct UriMemoryManagerStruct *, void *, size_t, size_t);
 
 /**
  * Function signature that custom free(3) functions must conform to
@@ -307,8 +307,8 @@ typedef enum UriResolutionOptionsEnum {
  * @see UriMemoryManager
  * @since 0.9.0
  */
-URI_PUBLIC int uriCompleteMemoryManager(UriMemoryManager * memory,
-                                        UriMemoryManager * backend);
+URI_PUBLIC int uriCompleteMemoryManager(
+        UriMemoryManager * memory, UriMemoryManager * backend);
 
 /**
  * Offers emulation of calloc(3) based on memory-&gt;malloc and memset.
@@ -341,8 +341,8 @@ URI_PUBLIC void * uriEmulateCalloc(UriMemoryManager * memory, size_t nmemb, size
  * @see UriMemoryManager
  * @since 0.9.0
  */
-URI_PUBLIC void * uriEmulateReallocarray(UriMemoryManager * memory, void * ptr,
-                                         size_t nmemb, size_t size);
+URI_PUBLIC void * uriEmulateReallocarray(
+        UriMemoryManager * memory, void * ptr, size_t nmemb, size_t size);
 
 /**
  * Run multiple tests against a given memory manager.
@@ -396,7 +396,7 @@ URI_PUBLIC int uriTestMemoryManager(UriMemoryManager * memory);
  * @see uriTestMemoryManager
  * @since 1.0.0
  */
-URI_PUBLIC int uriTestMemoryManagerEx(UriMemoryManager * memory,
-                                      UriBool challengeAlignment);
+URI_PUBLIC int uriTestMemoryManagerEx(
+        UriMemoryManager * memory, UriBool challengeAlignment);
 
 #endif /* URI_BASE_H */

--- a/include/uriparser/UriIp4.h
+++ b/include/uriparser/UriIp4.h
@@ -44,8 +44,8 @@
  */
 
 #if (defined(URI_PASS_ANSI) && !defined(URI_IP4_TWICE_H_ANSI)) \
-    || (defined(URI_PASS_UNICODE) && !defined(URI_IP4_TWICE_H_UNICODE)) \
-    || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+        || (defined(URI_PASS_UNICODE) && !defined(URI_IP4_TWICE_H_UNICODE)) \
+        || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* What encodings are enabled? */
 #  include "UriDefsConfig.h"
 #  if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
@@ -63,8 +63,8 @@
 /* Only one pass for each encoding */
 #  elif (defined(URI_PASS_ANSI) && !defined(URI_IP4_TWICE_H_ANSI) \
          && defined(URI_ENABLE_ANSI)) \
-      || (defined(URI_PASS_UNICODE) && !defined(URI_IP4_TWICE_H_UNICODE) \
-          && defined(URI_ENABLE_UNICODE))
+          || (defined(URI_PASS_UNICODE) && !defined(URI_IP4_TWICE_H_UNICODE) \
+              && defined(URI_ENABLE_UNICODE))
 #    ifdef URI_PASS_ANSI
 #      define URI_IP4_TWICE_H_ANSI 1
 #      include "UriDefsAnsi.h"

--- a/include/uriparser/UriIp4.h
+++ b/include/uriparser/UriIp4.h
@@ -62,9 +62,9 @@
 #    endif
 /* Only one pass for each encoding */
 #  elif (defined(URI_PASS_ANSI) && !defined(URI_IP4_TWICE_H_ANSI) \
-         && defined(URI_ENABLE_ANSI)) \
+          && defined(URI_ENABLE_ANSI)) \
           || (defined(URI_PASS_UNICODE) && !defined(URI_IP4_TWICE_H_UNICODE) \
-              && defined(URI_ENABLE_UNICODE))
+                  && defined(URI_ENABLE_UNICODE))
 #    ifdef URI_PASS_ANSI
 #      define URI_IP4_TWICE_H_ANSI 1
 #      include "UriDefsAnsi.h"
@@ -93,9 +93,8 @@ extern "C" {
  * @see uriParseIpSixAddressA
  * @see uriParseIpSixAddressMmA
  */
-URI_PUBLIC int URI_FUNC(ParseIpFourAddress)(unsigned char * octetOutput,
-                                            const URI_CHAR * first,
-                                            const URI_CHAR * afterLast);
+URI_PUBLIC int URI_FUNC(ParseIpFourAddress)(
+        unsigned char * octetOutput, const URI_CHAR * first, const URI_CHAR * afterLast);
 
 #    ifdef __cplusplus
 }

--- a/src/UriCommon.c
+++ b/src/UriCommon.c
@@ -89,7 +89,7 @@ int URI_FUNC(FreeUriPath)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
         while (segWalk != NULL) {
             URI_TYPE(PathSegment) * const next = segWalk->next;
             if ((uri->owner == URI_TRUE)
-                && (segWalk->text.first != segWalk->text.afterLast)) {
+                    && (segWalk->text.first != segWalk->text.afterLast)) {
                 memory->free(memory, (URI_CHAR *)segWalk->text.first);
             }
             segWalk->text.first = NULL;
@@ -128,8 +128,7 @@ bool URI_FUNC(RangeEquals)(const URI_TYPE(TextRange) * a, const URI_TYPE(TextRan
 }
 
 UriBool URI_FUNC(CopyRange)(URI_TYPE(TextRange) * destRange,
-                            const URI_TYPE(TextRange) * sourceRange,
-                            UriMemoryManager * memory) {
+        const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory) {
     const size_t lenInChars = sourceRange->afterLast - sourceRange->first;
     if (lenInChars > SIZE_MAX / sizeof(URI_CHAR)) {  // detect integer overflow
         return URI_FALSE;
@@ -147,8 +146,7 @@ UriBool URI_FUNC(CopyRange)(URI_TYPE(TextRange) * destRange,
 }
 
 UriBool URI_FUNC(CopyRangeAsNeeded)(URI_TYPE(TextRange) * destRange,
-                                    const URI_TYPE(TextRange) * sourceRange,
-                                    UriMemoryManager * memory) {
+        const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory) {
     if (sourceRange->first == NULL) {
         destRange->first = NULL;
         destRange->afterLast = NULL;
@@ -163,7 +161,7 @@ UriBool URI_FUNC(CopyRangeAsNeeded)(URI_TYPE(TextRange) * destRange,
 }
 
 UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
-                                      UriBool pathOwned, UriMemoryManager * memory) {
+        UriBool pathOwned, UriMemoryManager * memory) {
     URI_TYPE(PathSegment) * walker;
     if ((uri == NULL) || (uri->pathHead == NULL)) {
         return URI_TRUE;
@@ -198,7 +196,7 @@ UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
                 if ((walker == uri->pathHead) && (walker->next != NULL)) {
                     /* Detect case "/.//" (with or without scheme) */
                     if ((walker->next->text.first == walker->next->text.afterLast)
-                        && (URI_FUNC(HasHost)(uri) == URI_FALSE)) {
+                            && (URI_FUNC(HasHost)(uri) == URI_FALSE)) {
                         removeSegment = URI_FALSE;
                         /* Detect case "./withcolon:" */
                     } else if (relative) {
@@ -271,7 +269,7 @@ UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
 
         case 2:
             if (((walker->text.first)[0] == _UT('.'))
-                && ((walker->text.first)[1] == _UT('.'))) {
+                    && ((walker->text.first)[1] == _UT('.'))) {
                 /* Path ".." -> remove this and the previous segment */
                 URI_TYPE(PathSegment) * const prev = walker->reserved;
                 URI_TYPE(PathSegment) * prevPrev;
@@ -317,17 +315,18 @@ UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
                                         memory, 1, sizeof(URI_TYPE(PathSegment)));
                                 if (segment == NULL) {
                                     if (pathOwned
-                                        && (walker->text.first
-                                            != walker->text.afterLast)) {
-                                        memory->free(memory,
-                                                     (URI_CHAR *)walker->text.first);
+                                            && (walker->text.first
+                                                    != walker->text.afterLast)) {
+                                        memory->free(
+                                                memory, (URI_CHAR *)walker->text.first);
                                     }
                                     memory->free(memory, walker);
 
                                     if (pathOwned
-                                        && (prev->text.first != prev->text.afterLast)) {
-                                        memory->free(memory,
-                                                     (URI_CHAR *)prev->text.first);
+                                            && (prev->text.first
+                                                    != prev->text.afterLast)) {
+                                        memory->free(
+                                                memory, (URI_CHAR *)prev->text.first);
                                     }
                                     memory->free(memory, prev);
 
@@ -340,7 +339,7 @@ UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
                             }
 
                             if (pathOwned
-                                && (walker->text.first != walker->text.afterLast)) {
+                                    && (walker->text.first != walker->text.afterLast)) {
                                 memory->free(memory, (URI_CHAR *)walker->text.first);
                             }
                             memory->free(memory, walker);
@@ -358,7 +357,8 @@ UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
                                 walker->next->reserved = NULL;
 
                                 if (pathOwned
-                                    && (walker->text.first != walker->text.afterLast)) {
+                                        && (walker->text.first
+                                                != walker->text.afterLast)) {
                                     memory->free(memory, (URI_CHAR *)walker->text.first);
                                 }
                                 memory->free(memory, walker);
@@ -367,7 +367,8 @@ UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
                                  * slash, update tail */
                                 URI_TYPE(PathSegment) * const segment = walker;
                                 if (pathOwned
-                                    && (segment->text.first != segment->text.afterLast)) {
+                                        && (segment->text.first
+                                                != segment->text.afterLast)) {
                                     memory->free(memory, (URI_CHAR *)segment->text.first);
                                 }
                                 segment->text.first = URI_FUNC(SafeToPointTo);
@@ -413,7 +414,8 @@ UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
                                 /* Reuse segment for "" path segment to represent trailing
                                  * slash, then update head and tail */
                                 if (pathOwned
-                                    && (walker->text.first != walker->text.afterLast)) {
+                                        && (walker->text.first
+                                                != walker->text.afterLast)) {
                                     memory->free(memory, (URI_CHAR *)walker->text.first);
                                 }
                                 walker->text.first = URI_FUNC(SafeToPointTo);
@@ -424,7 +426,7 @@ UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
 
                         if (freeWalker) {
                             if (pathOwned
-                                && (walker->text.first != walker->text.afterLast)) {
+                                    && (walker->text.first != walker->text.afterLast)) {
                                 memory->free(memory, (URI_CHAR *)walker->text.first);
                             }
                             memory->free(memory, walker);
@@ -453,8 +455,8 @@ UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
 }
 
 /* Properly removes "." and ".." path segments */
-UriBool URI_FUNC(RemoveDotSegmentsAbsolute)(URI_TYPE(Uri) * uri,
-                                            UriMemoryManager * memory) {
+UriBool URI_FUNC(RemoveDotSegmentsAbsolute)(
+        URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
     const UriBool ABSOLUTE = URI_FALSE;
     if (uri == NULL) {
         return URI_TRUE;
@@ -523,12 +525,12 @@ UriBool URI_FUNC(HasHost)(const URI_TYPE(Uri) * uri) {
      *       no more information to be gained.                */
     return (uri != NULL)
            && ((uri->hostText.first != NULL) || (uri->hostData.ip4 != NULL)
-               || (uri->hostData.ip6 != NULL));
+                   || (uri->hostData.ip6 != NULL));
 }
 
 /* Copies the path segment list from one URI to another. */
-UriBool URI_FUNC(CopyPath)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source,
-                           UriMemoryManager * memory) {
+UriBool URI_FUNC(CopyPath)(
+        URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source, UriMemoryManager * memory) {
     if (source->pathHead == NULL) {
         /* No path component */
         dest->pathHead = NULL;
@@ -569,8 +571,8 @@ UriBool URI_FUNC(CopyPath)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source,
 }
 
 /* Copies the authority part of an URI over to another. */
-UriBool URI_FUNC(CopyAuthority)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source,
-                                UriMemoryManager * memory) {
+UriBool URI_FUNC(CopyAuthority)(
+        URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source, UriMemoryManager * memory) {
     /* From this functions usage we know that *
      * the dest URI cannot be uri->owner      */
 
@@ -615,14 +617,15 @@ UriBool URI_FUNC(FixAmbiguity)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
     URI_TYPE(PathSegment) * segment;
 
     if (/* Case 1: absolute path, empty first segment */
-        (uri->absolutePath && (uri->pathHead != NULL)
-         && (uri->pathHead->text.afterLast == uri->pathHead->text.first))
+            (uri->absolutePath && (uri->pathHead != NULL)
+                    && (uri->pathHead->text.afterLast == uri->pathHead->text.first))
 
-        /* Case 2: relative path, empty first and second segment */
-        || (!uri->absolutePath && (uri->pathHead != NULL) && (uri->pathHead->next != NULL)
-            && (uri->pathHead->text.afterLast == uri->pathHead->text.first)
-            && (uri->pathHead->next->text.afterLast
-                == uri->pathHead->next->text.first))) {
+            /* Case 2: relative path, empty first and second segment */
+            || (!uri->absolutePath && (uri->pathHead != NULL)
+                    && (uri->pathHead->next != NULL)
+                    && (uri->pathHead->text.afterLast == uri->pathHead->text.first)
+                    && (uri->pathHead->next->text.afterLast
+                            == uri->pathHead->next->text.first))) {
         /* NOOP */
     } else {
         return URI_TRUE;
@@ -641,8 +644,8 @@ UriBool URI_FUNC(FixAmbiguity)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
     return URI_TRUE;
 }
 
-static UriBool URI_FUNC(PrependNewDotSegment)(URI_TYPE(Uri) * uri,
-                                              UriMemoryManager * memory) {
+static UriBool URI_FUNC(PrependNewDotSegment)(
+        URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
     assert(uri != NULL);
     assert(memory != NULL);
 
@@ -695,7 +698,7 @@ UriBool URI_FUNC(FixPathNoScheme)(URI_TYPE(Uri) * uri, UriMemoryManager * memory
     assert(memory != NULL);
 
     if ((uri->absolutePath == URI_TRUE) || (uri->pathHead == NULL)
-        || (uri->scheme.first != NULL) || URI_FUNC(HasHost)(uri)) {
+            || (uri->scheme.first != NULL) || URI_FUNC(HasHost)(uri)) {
         return URI_TRUE; /* i.e. nothing to do */
     }
 
@@ -735,15 +738,15 @@ UriBool URI_FUNC(FixPathNoScheme)(URI_TYPE(Uri) * uri, UriMemoryManager * memory
  * Returns URI_TRUE for (a) nothing to do or (b) successful changes.
  * Returns URI_FALSE to signal out-of-memory.
  */
-UriBool URI_FUNC(EnsureThatPathIsNotMistakenForHost)(URI_TYPE(Uri) * uri,
-                                                     UriMemoryManager * memory) {
+UriBool URI_FUNC(EnsureThatPathIsNotMistakenForHost)(
+        URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
     assert(uri != NULL);
     assert(memory != NULL);
 
     if ((URI_FUNC(HasHost)(uri) == URI_TRUE) || (uri->absolutePath == URI_FALSE)
-        || (uri->pathHead == NULL)
-        || (uri->pathHead == uri->pathTail) /* i.e. no second slash */
-        || (uri->pathHead->text.first != uri->pathHead->text.afterLast)) {
+            || (uri->pathHead == NULL)
+            || (uri->pathHead == uri->pathTail) /* i.e. no second slash */
+            || (uri->pathHead->text.first != uri->pathHead->text.afterLast)) {
         return URI_TRUE; /* i.e. nothing to do */
     }
 
@@ -754,8 +757,8 @@ UriBool URI_FUNC(EnsureThatPathIsNotMistakenForHost)(URI_TYPE(Uri) * uri,
 void URI_FUNC(FixEmptyTrailSegment)(URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
     /* Fix path if only one empty segment */
     if (!uri->absolutePath && !URI_FUNC(HasHost)(uri) && (uri->pathHead != NULL)
-        && (uri->pathHead->next == NULL)
-        && (uri->pathHead->text.first == uri->pathHead->text.afterLast)) {
+            && (uri->pathHead->next == NULL)
+            && (uri->pathHead->text.first == uri->pathHead->text.afterLast)) {
         memory->free(memory, uri->pathHead);
         uri->pathHead = NULL;
         uri->pathTail = NULL;

--- a/src/UriCommon.c
+++ b/src/UriCommon.c
@@ -314,7 +314,7 @@ UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
                                 /* Last segment -> insert "" segment to represent trailing
                                  * slash, update tail */
                                 URI_TYPE(PathSegment) * const segment = memory->calloc(
-                                    memory, 1, sizeof(URI_TYPE(PathSegment)));
+                                        memory, 1, sizeof(URI_TYPE(PathSegment)));
                                 if (segment == NULL) {
                                     if (pathOwned
                                         && (walker->text.first
@@ -539,7 +539,7 @@ UriBool URI_FUNC(CopyPath)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source,
         URI_TYPE(PathSegment) * destPrev = NULL;
         do {
             URI_TYPE(PathSegment) * cur =
-                memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
+                    memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
             if (cur == NULL) {
                 /* Fix broken list */
                 if (destPrev != NULL) {
@@ -647,7 +647,7 @@ static UriBool URI_FUNC(PrependNewDotSegment)(URI_TYPE(Uri) * uri,
     assert(memory != NULL);
 
     URI_TYPE(PathSegment) * const segment =
-        memory->malloc(memory, 1 * sizeof(URI_TYPE(PathSegment)));
+            memory->malloc(memory, 1 * sizeof(URI_TYPE(PathSegment)));
 
     if (segment == NULL) {
         return URI_FALSE; /* i.e. raise malloc error */

--- a/src/UriCommon.h
+++ b/src/UriCommon.h
@@ -38,8 +38,8 @@
  */
 
 #if (defined(URI_PASS_ANSI) && !defined(URI_COMMON_H_ANSI)) \
-    || (defined(URI_PASS_UNICODE) && !defined(URI_COMMON_H_UNICODE)) \
-    || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+        || (defined(URI_PASS_UNICODE) && !defined(URI_COMMON_H_UNICODE)) \
+        || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* What encodings are enabled? */
 #  include <uriparser/UriDefsConfig.h>
 #  if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
@@ -57,8 +57,8 @@
 /* Only one pass for each encoding */
 #  elif (defined(URI_PASS_ANSI) && !defined(URI_COMMON_H_ANSI) \
          && defined(URI_ENABLE_ANSI)) \
-      || (defined(URI_PASS_UNICODE) && !defined(URI_COMMON_H_UNICODE) \
-          && defined(URI_ENABLE_UNICODE))
+          || (defined(URI_PASS_UNICODE) && !defined(URI_COMMON_H_UNICODE) \
+              && defined(URI_ENABLE_UNICODE))
 #    ifdef URI_PASS_ANSI
 #      define URI_COMMON_H_ANSI 1
 #      include <uriparser/UriDefsAnsi.h>

--- a/src/UriCommon.h
+++ b/src/UriCommon.h
@@ -56,9 +56,9 @@
 #    endif
 /* Only one pass for each encoding */
 #  elif (defined(URI_PASS_ANSI) && !defined(URI_COMMON_H_ANSI) \
-         && defined(URI_ENABLE_ANSI)) \
+          && defined(URI_ENABLE_ANSI)) \
           || (defined(URI_PASS_UNICODE) && !defined(URI_COMMON_H_UNICODE) \
-              && defined(URI_ENABLE_UNICODE))
+                  && defined(URI_ENABLE_UNICODE))
 #    ifdef URI_PASS_ANSI
 #      define URI_COMMON_H_ANSI 1
 #      include <uriparser/UriDefsAnsi.h>
@@ -82,29 +82,27 @@ int URI_FUNC(FreeUriPath)(URI_TYPE(Uri) * uri, UriMemoryManager * memory);
 bool URI_FUNC(RangeEquals)(const URI_TYPE(TextRange) * a, const URI_TYPE(TextRange) * b);
 
 UriBool URI_FUNC(CopyRange)(URI_TYPE(TextRange) * destRange,
-                            const URI_TYPE(TextRange) * sourceRange,
-                            UriMemoryManager * memory);
+        const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory);
 UriBool URI_FUNC(CopyRangeAsNeeded)(URI_TYPE(TextRange) * destRange,
-                                    const URI_TYPE(TextRange) * sourceRange,
-                                    UriMemoryManager * memory);
+        const URI_TYPE(TextRange) * sourceRange, UriMemoryManager * memory);
 
-UriBool URI_FUNC(RemoveDotSegmentsAbsolute)(URI_TYPE(Uri) * uri,
-                                            UriMemoryManager * memory);
+UriBool URI_FUNC(RemoveDotSegmentsAbsolute)(
+        URI_TYPE(Uri) * uri, UriMemoryManager * memory);
 UriBool URI_FUNC(RemoveDotSegmentsEx)(URI_TYPE(Uri) * uri, UriBool relative,
-                                      UriBool pathOwned, UriMemoryManager * memory);
+        UriBool pathOwned, UriMemoryManager * memory);
 
 unsigned char URI_FUNC(HexdigToInt)(URI_CHAR hexdig);
 URI_CHAR URI_FUNC(HexToLetterEx)(unsigned int value, UriBool uppercase);
 
-UriBool URI_FUNC(CopyPath)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source,
-                           UriMemoryManager * memory);
-UriBool URI_FUNC(CopyAuthority)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source,
-                                UriMemoryManager * memory);
+UriBool URI_FUNC(CopyPath)(
+        URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source, UriMemoryManager * memory);
+UriBool URI_FUNC(CopyAuthority)(
+        URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * source, UriMemoryManager * memory);
 
 UriBool URI_FUNC(FixAmbiguity)(URI_TYPE(Uri) * uri, UriMemoryManager * memory);
 UriBool URI_FUNC(FixPathNoScheme)(URI_TYPE(Uri) * uri, UriMemoryManager * memory);
-UriBool URI_FUNC(EnsureThatPathIsNotMistakenForHost)(URI_TYPE(Uri) * uri,
-                                                     UriMemoryManager * memory);
+UriBool URI_FUNC(EnsureThatPathIsNotMistakenForHost)(
+        URI_TYPE(Uri) * uri, UriMemoryManager * memory);
 void URI_FUNC(FixEmptyTrailSegment)(URI_TYPE(Uri) * uri, UriMemoryManager * memory);
 
 #  endif

--- a/src/UriCompare.c
+++ b/src/UriCompare.c
@@ -88,9 +88,9 @@ UriBool URI_FUNC(EqualsUri)(const URI_TYPE(Uri) * a, const URI_TYPE(Uri) * b) {
 
     /* Host */
     if (((a->hostData.ip4 == NULL) != (b->hostData.ip4 == NULL))
-        || ((a->hostData.ip6 == NULL) != (b->hostData.ip6 == NULL))
-        || ((a->hostData.ipFuture.first == NULL)
-            != (b->hostData.ipFuture.first == NULL))) {
+            || ((a->hostData.ip6 == NULL) != (b->hostData.ip6 == NULL))
+            || ((a->hostData.ipFuture.first == NULL)
+                    != (b->hostData.ipFuture.first == NULL))) {
         return URI_FALSE;
     }
 
@@ -113,7 +113,7 @@ UriBool URI_FUNC(EqualsUri)(const URI_TYPE(Uri) * a, const URI_TYPE(Uri) * b) {
     }
 
     if ((a->hostData.ip4 == NULL) && (a->hostData.ip6 == NULL)
-        && (a->hostData.ipFuture.first == NULL)) {
+            && (a->hostData.ipFuture.first == NULL)) {
         if (!URI_FUNC(RangeEquals)(&(a->hostText), &(b->hostText))) {
             return URI_FALSE;
         }

--- a/src/UriCopy.c
+++ b/src/UriCopy.c
@@ -180,7 +180,7 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri
 
         while (sourceWalker != NULL) {
             URI_TYPE(PathSegment) * destWalker =
-                memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
+                    memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
             if (destWalker == NULL) {
                 URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
                 return URI_ERROR_MALLOC;

--- a/src/UriCopy.c
+++ b/src/UriCopy.c
@@ -74,9 +74,8 @@
 #    include "UriCopy.h"
 #  endif
 
-static void URI_FUNC(PreventLeakageAfterCopy)(URI_TYPE(Uri) * uri,
-                                              unsigned int revertMask,
-                                              UriMemoryManager * memory) {
+static void URI_FUNC(PreventLeakageAfterCopy)(
+        URI_TYPE(Uri) * uri, unsigned int revertMask, UriMemoryManager * memory) {
     URI_FUNC(PreventLeakage)(uri, revertMask, memory);
 
     if (uri->hostData.ip4 != NULL) {
@@ -97,7 +96,7 @@ static void URI_FUNC(PreventLeakageAfterCopy)(URI_TYPE(Uri) * uri,
 }
 
 int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri,
-                        UriMemoryManager * memory) {
+        UriMemoryManager * memory) {
     unsigned int revertMask = URI_NORMALIZED;
 
     if (sourceUri == NULL || destUri == NULL) {
@@ -109,14 +108,14 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri
     URI_FUNC(ResetUri)(destUri);
 
     if (URI_FUNC(CopyRangeAsNeeded)(&destUri->scheme, &sourceUri->scheme, memory)
-        == URI_FALSE) {
+            == URI_FALSE) {
         return URI_ERROR_MALLOC;
     }
 
     revertMask |= URI_NORMALIZE_SCHEME;
 
     if (URI_FUNC(CopyRangeAsNeeded)(&destUri->userInfo, &sourceUri->userInfo, memory)
-        == URI_FALSE) {
+            == URI_FALSE) {
         URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
         return URI_ERROR_MALLOC;
     }
@@ -124,7 +123,7 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri
     revertMask |= URI_NORMALIZE_USER_INFO;
 
     if (URI_FUNC(CopyRangeAsNeeded)(&destUri->hostText, &sourceUri->hostText, memory)
-        == URI_FALSE) {
+            == URI_FALSE) {
         URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
         return URI_ERROR_MALLOC;
     }
@@ -156,15 +155,15 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri
     if (sourceUri->hostData.ipFuture.first != NULL) {
         destUri->hostData.ipFuture.first = destUri->hostText.first;
         destUri->hostData.ipFuture.afterLast = destUri->hostText.afterLast;
-    } else if (URI_FUNC(CopyRangeAsNeeded)(&destUri->hostData.ipFuture,
-                                           &sourceUri->hostData.ipFuture, memory)
+    } else if (URI_FUNC(CopyRangeAsNeeded)(
+                       &destUri->hostData.ipFuture, &sourceUri->hostData.ipFuture, memory)
                == URI_FALSE) {
         URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
         return URI_ERROR_MALLOC;
     }
 
     if (URI_FUNC(CopyRangeAsNeeded)(&destUri->portText, &sourceUri->portText, memory)
-        == URI_FALSE) {
+            == URI_FALSE) {
         URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
         return URI_ERROR_MALLOC;
     }
@@ -196,9 +195,9 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri
                 revertMask |= URI_NORMALIZE_PATH;
             }
 
-            if (URI_FUNC(CopyRangeAsNeeded)(&destWalker->text, &sourceWalker->text,
-                                            memory)
-                == URI_FALSE) {
+            if (URI_FUNC(CopyRangeAsNeeded)(
+                        &destWalker->text, &sourceWalker->text, memory)
+                    == URI_FALSE) {
                 // Unless wired to `destUri` above, `destWalker` may be hanging
                 // in the air now
                 if (destUri->pathHead != destWalker) {
@@ -221,7 +220,7 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri
     }
 
     if (URI_FUNC(CopyRangeAsNeeded)(&destUri->query, &sourceUri->query, memory)
-        == URI_FALSE) {
+            == URI_FALSE) {
         URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
         return URI_ERROR_MALLOC;
     }
@@ -229,7 +228,7 @@ int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri
     revertMask |= URI_NORMALIZE_QUERY;
 
     if (URI_FUNC(CopyRangeAsNeeded)(&destUri->fragment, &sourceUri->fragment, memory)
-        == URI_FALSE) {
+            == URI_FALSE) {
         URI_FUNC(PreventLeakageAfterCopy)(destUri, revertMask, memory);
         return URI_ERROR_MALLOC;
     }

--- a/src/UriCopy.h
+++ b/src/UriCopy.h
@@ -39,8 +39,8 @@
  */
 
 #if (defined(URI_PASS_ANSI) && !defined(URI_COPY_H_ANSI)) \
-    || (defined(URI_PASS_UNICODE) && !defined(URI_COPY_H_UNICODE)) \
-    || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+        || (defined(URI_PASS_UNICODE) && !defined(URI_COPY_H_UNICODE)) \
+        || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* What encodings are enabled? */
 #  include <uriparser/UriDefsConfig.h>
 #  if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
@@ -58,8 +58,8 @@
 /* Only one pass for each encoding */
 #  elif (defined(URI_PASS_ANSI) && !defined(URI_COPY_H_ANSI) \
          && defined(URI_ENABLE_ANSI)) \
-      || (defined(URI_PASS_UNICODE) && !defined(URI_COPY_H_UNICODE) \
-          && defined(URI_ENABLE_UNICODE))
+          || (defined(URI_PASS_UNICODE) && !defined(URI_COPY_H_UNICODE) \
+              && defined(URI_ENABLE_UNICODE))
 #    ifdef URI_PASS_ANSI
 #      define URI_COPY_H_ANSI 1
 #      include <uriparser/UriDefsAnsi.h>

--- a/src/UriCopy.h
+++ b/src/UriCopy.h
@@ -57,9 +57,9 @@
 #    endif
 /* Only one pass for each encoding */
 #  elif (defined(URI_PASS_ANSI) && !defined(URI_COPY_H_ANSI) \
-         && defined(URI_ENABLE_ANSI)) \
+          && defined(URI_ENABLE_ANSI)) \
           || (defined(URI_PASS_UNICODE) && !defined(URI_COPY_H_UNICODE) \
-              && defined(URI_ENABLE_UNICODE))
+                  && defined(URI_ENABLE_UNICODE))
 #    ifdef URI_PASS_ANSI
 #      define URI_COPY_H_ANSI 1
 #      include <uriparser/UriDefsAnsi.h>
@@ -69,7 +69,7 @@
 #    endif
 
 int URI_FUNC(CopyUriMm)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri,
-                        UriMemoryManager * memory);
+        UriMemoryManager * memory);
 int URI_FUNC(CopyUri)(URI_TYPE(Uri) * destUri, const URI_TYPE(Uri) * sourceUri);
 
 #  endif

--- a/src/UriEscape.c
+++ b/src/UriEscape.c
@@ -66,13 +66,12 @@
 #  endif
 
 URI_CHAR * URI_FUNC(Escape)(const URI_CHAR * in, URI_CHAR * out, UriBool spaceToPlus,
-                            UriBool normalizeBreaks) {
+        UriBool normalizeBreaks) {
     return URI_FUNC(EscapeEx)(in, NULL, out, spaceToPlus, normalizeBreaks);
 }
 
 URI_CHAR * URI_FUNC(EscapeEx)(const URI_CHAR * inFirst, const URI_CHAR * inAfterLast,
-                              URI_CHAR * out, UriBool spaceToPlus,
-                              UriBool normalizeBreaks) {
+        URI_CHAR * out, UriBool spaceToPlus, UriBool normalizeBreaks) {
     const URI_CHAR * read = inFirst;
     URI_CHAR * write = out;
     UriBool prevWasCr = URI_FALSE;
@@ -179,8 +178,8 @@ const URI_CHAR * URI_FUNC(UnescapeInPlace)(URI_CHAR * inout) {
     return URI_FUNC(UnescapeInPlaceEx)(inout, URI_FALSE, URI_BR_DONT_TOUCH);
 }
 
-const URI_CHAR * URI_FUNC(UnescapeInPlaceEx)(URI_CHAR * inout, UriBool plusToSpace,
-                                             UriBreakConversion breakConversion) {
+const URI_CHAR * URI_FUNC(UnescapeInPlaceEx)(
+        URI_CHAR * inout, UriBool plusToSpace, UriBreakConversion breakConversion) {
     URI_CHAR * read = inout;
     URI_CHAR * write = inout;
     UriBool prevWasCr = URI_FALSE;

--- a/src/UriFile.c
+++ b/src/UriFile.c
@@ -66,9 +66,8 @@
 #  include <stddef.h>  // size_t
 #  include <stdint.h>  // SIZE_MAX
 
-static URI_INLINE int URI_FUNC(FilenameToUriString)(const URI_CHAR * filename,
-                                                    URI_CHAR * uriString,
-                                                    UriBool fromUnix) {
+static URI_INLINE int URI_FUNC(FilenameToUriString)(
+        const URI_CHAR * filename, URI_CHAR * uriString, UriBool fromUnix) {
     const URI_CHAR * input = filename;
     const URI_CHAR * afterLastSep = input;
     UriBool firstSegment = URI_TRUE;
@@ -83,7 +82,7 @@ static URI_INLINE int URI_FUNC(FilenameToUriString)(const URI_CHAR * filename,
     is_windows_network = (filename[0] == _UT('\\')) && (filename[1] == _UT('\\'));
     absolute = fromUnix ? (filename[0] == _UT('/'))
                         : (((filename[0] != _UT('\0')) && (filename[1] == _UT(':')))
-                           || is_windows_network);
+                                  || is_windows_network);
 
     if (absolute) {
         const URI_CHAR * const prefix = fromUnix             ? _UT("file://")
@@ -104,7 +103,7 @@ static URI_INLINE int URI_FUNC(FilenameToUriString)(const URI_CHAR * filename,
     /* Copy and escape on the fly */
     for (;;) {
         if ((input[0] == _UT('\0')) || (fromUnix && input[0] == _UT('/'))
-            || (!fromUnix && input[0] == _UT('\\'))) {
+                || (!fromUnix && input[0] == _UT('\\'))) {
             /* Copy text after last separator */
             if (afterLastSep < input) {
                 if (!fromUnix && absolute && (firstSegment == URI_TRUE)) {
@@ -119,8 +118,8 @@ static URI_INLINE int URI_FUNC(FilenameToUriString)(const URI_CHAR * filename,
                     memcpy(output, afterLastSep, charsToCopy * sizeof(URI_CHAR));
                     output += charsToCopy;
                 } else {
-                    output = URI_FUNC(EscapeEx)(afterLastSep, input, output, URI_FALSE,
-                                                URI_FALSE);
+                    output = URI_FUNC(EscapeEx)(
+                            afterLastSep, input, output, URI_FALSE, URI_FALSE);
                 }
             }
             firstSegment = URI_FALSE;
@@ -146,8 +145,8 @@ static URI_INLINE int URI_FUNC(FilenameToUriString)(const URI_CHAR * filename,
     return URI_SUCCESS;
 }
 
-static URI_INLINE int URI_FUNC(UriStringToFilename)(const URI_CHAR * uriString,
-                                                    URI_CHAR * filename, UriBool toUnix) {
+static URI_INLINE int URI_FUNC(UriStringToFilename)(
+        const URI_CHAR * uriString, URI_CHAR * filename, UriBool toUnix) {
     if ((uriString == NULL) || (filename == NULL)) {
         return URI_ERROR_NULL;
     }
@@ -163,7 +162,7 @@ static URI_INLINE int URI_FUNC(UriStringToFilename)(const URI_CHAR * uriString,
     const UriBool file_three_or_more_slashes =
             file_two_or_more_slashes
             && (URI_STRNCMP(uriString, _UT("file:///"), URI_STRLEN(_UT("file:///")))
-                == 0);
+                    == 0);
 
     const size_t charsToSkip =
             file_two_or_more_slashes
@@ -176,16 +175,16 @@ static URI_INLINE int URI_FUNC(UriStringToFilename)(const URI_CHAR * uriString,
                               /* file://Server01/Letter.txt */
                               : URI_STRLEN(_UT("file://"))
                     : ((file_one_or_more_slashes && toUnix)
-                               /* file:/bin/bash */
-                               /* https://tools.ietf.org/html/rfc8089#appendix-B */
-                               ? URI_STRLEN(_UT("file:"))
-                               : ((!toUnix && file_unknown_slashes
-                                   && !file_one_or_more_slashes)
-                                          /* file:c:/path/to/file */
-                                          /* https://tools.ietf.org/html/rfc8089#appendix-E.2
-                                           */
-                                          ? URI_STRLEN(_UT("file:"))
-                                          : 0));
+                                      /* file:/bin/bash */
+                                      /* https://tools.ietf.org/html/rfc8089#appendix-B */
+                                      ? URI_STRLEN(_UT("file:"))
+                                      : ((!toUnix && file_unknown_slashes
+                                                 && !file_one_or_more_slashes)
+                                                        /* file:c:/path/to/file */
+                                                        /* https://tools.ietf.org/html/rfc8089#appendix-E.2
+                                                         */
+                                                        ? URI_STRLEN(_UT("file:"))
+                                                        : 0));
     const size_t charsToCopy = URI_STRLEN(uriString + charsToSkip) + 1;
 
     const UriBool is_windows_network_with_authority = (toUnix == URI_FALSE)
@@ -221,8 +220,8 @@ int URI_FUNC(UnixFilenameToUriString)(const URI_CHAR * filename, URI_CHAR * uriS
     return URI_FUNC(FilenameToUriString)(filename, uriString, URI_TRUE);
 }
 
-int URI_FUNC(WindowsFilenameToUriString)(const URI_CHAR * filename,
-                                         URI_CHAR * uriString) {
+int URI_FUNC(WindowsFilenameToUriString)(
+        const URI_CHAR * filename, URI_CHAR * uriString) {
     return URI_FUNC(FilenameToUriString)(filename, uriString, URI_FALSE);
 }
 
@@ -230,8 +229,8 @@ int URI_FUNC(UriStringToUnixFilename)(const URI_CHAR * uriString, URI_CHAR * fil
     return URI_FUNC(UriStringToFilename)(uriString, filename, URI_TRUE);
 }
 
-int URI_FUNC(UriStringToWindowsFilename)(const URI_CHAR * uriString,
-                                         URI_CHAR * filename) {
+int URI_FUNC(UriStringToWindowsFilename)(
+        const URI_CHAR * uriString, URI_CHAR * filename) {
     return URI_FUNC(UriStringToFilename)(uriString, filename, URI_FALSE);
 }
 

--- a/src/UriFile.c
+++ b/src/UriFile.c
@@ -153,42 +153,47 @@ static URI_INLINE int URI_FUNC(UriStringToFilename)(const URI_CHAR * uriString,
     }
 
     const UriBool file_unknown_slashes =
-        URI_STRNCMP(uriString, _UT("file:"), URI_STRLEN(_UT("file:"))) == 0;
+            URI_STRNCMP(uriString, _UT("file:"), URI_STRLEN(_UT("file:"))) == 0;
     const UriBool file_one_or_more_slashes =
-        file_unknown_slashes
-        && (URI_STRNCMP(uriString, _UT("file:/"), URI_STRLEN(_UT("file:/"))) == 0);
+            file_unknown_slashes
+            && (URI_STRNCMP(uriString, _UT("file:/"), URI_STRLEN(_UT("file:/"))) == 0);
     const UriBool file_two_or_more_slashes =
-        file_one_or_more_slashes
-        && (URI_STRNCMP(uriString, _UT("file://"), URI_STRLEN(_UT("file://"))) == 0);
+            file_one_or_more_slashes
+            && (URI_STRNCMP(uriString, _UT("file://"), URI_STRLEN(_UT("file://"))) == 0);
     const UriBool file_three_or_more_slashes =
-        file_two_or_more_slashes
-        && (URI_STRNCMP(uriString, _UT("file:///"), URI_STRLEN(_UT("file:///"))) == 0);
+            file_two_or_more_slashes
+            && (URI_STRNCMP(uriString, _UT("file:///"), URI_STRLEN(_UT("file:///")))
+                == 0);
 
     const size_t charsToSkip =
-        file_two_or_more_slashes
-            ? file_three_or_more_slashes ? toUnix
-                                               /* file:///bin/bash */
-                                               ? URI_STRLEN(_UT("file://"))
-                                               /* file:///E:/Documents%20and%20Settings */
-                                               : URI_STRLEN(_UT("file:///"))
-                                         /* file://Server01/Letter.txt */
-                                         : URI_STRLEN(_UT("file://"))
-            : ((file_one_or_more_slashes && toUnix)
-                   /* file:/bin/bash */
-                   /* https://tools.ietf.org/html/rfc8089#appendix-B */
-                   ? URI_STRLEN(_UT("file:"))
-                   : ((!toUnix && file_unknown_slashes && !file_one_or_more_slashes)
-                          /* file:c:/path/to/file */
-                          /* https://tools.ietf.org/html/rfc8089#appendix-E.2 */
-                          ? URI_STRLEN(_UT("file:"))
-                          : 0));
+            file_two_or_more_slashes
+                    ? file_three_or_more_slashes
+                              ? toUnix
+                                        /* file:///bin/bash */
+                                        ? URI_STRLEN(_UT("file://"))
+                                        /* file:///E:/Documents%20and%20Settings */
+                                        : URI_STRLEN(_UT("file:///"))
+                              /* file://Server01/Letter.txt */
+                              : URI_STRLEN(_UT("file://"))
+                    : ((file_one_or_more_slashes && toUnix)
+                               /* file:/bin/bash */
+                               /* https://tools.ietf.org/html/rfc8089#appendix-B */
+                               ? URI_STRLEN(_UT("file:"))
+                               : ((!toUnix && file_unknown_slashes
+                                   && !file_one_or_more_slashes)
+                                          /* file:c:/path/to/file */
+                                          /* https://tools.ietf.org/html/rfc8089#appendix-E.2
+                                           */
+                                          ? URI_STRLEN(_UT("file:"))
+                                          : 0));
     const size_t charsToCopy = URI_STRLEN(uriString + charsToSkip) + 1;
 
-    const UriBool is_windows_network_with_authority =
-        (toUnix == URI_FALSE) && file_two_or_more_slashes && !file_three_or_more_slashes;
+    const UriBool is_windows_network_with_authority = (toUnix == URI_FALSE)
+                                                      && file_two_or_more_slashes
+                                                      && !file_three_or_more_slashes;
 
     URI_CHAR * const unescape_target =
-        is_windows_network_with_authority ? (filename + 2) : filename;
+            is_windows_network_with_authority ? (filename + 2) : filename;
 
     if (is_windows_network_with_authority) {
         filename[0] = '\\';

--- a/src/UriIp4.c
+++ b/src/UriIp4.c
@@ -72,27 +72,22 @@
 #  endif
 
 /* Prototypes */
-static const URI_CHAR * URI_FUNC(ParseDecOctet)(UriIp4Parser * parser,
-                                                const URI_CHAR * first,
-                                                const URI_CHAR * afterLast);
-static const URI_CHAR * URI_FUNC(ParseDecOctetOne)(UriIp4Parser * parser,
-                                                   const URI_CHAR * first,
-                                                   const URI_CHAR * afterLast);
-static const URI_CHAR * URI_FUNC(ParseDecOctetTwo)(UriIp4Parser * parser,
-                                                   const URI_CHAR * first,
-                                                   const URI_CHAR * afterLast);
-static const URI_CHAR * URI_FUNC(ParseDecOctetThree)(UriIp4Parser * parser,
-                                                     const URI_CHAR * first,
-                                                     const URI_CHAR * afterLast);
-static const URI_CHAR * URI_FUNC(ParseDecOctetFour)(UriIp4Parser * parser,
-                                                    const URI_CHAR * first,
-                                                    const URI_CHAR * afterLast);
+static const URI_CHAR * URI_FUNC(ParseDecOctet)(
+        UriIp4Parser * parser, const URI_CHAR * first, const URI_CHAR * afterLast);
+static const URI_CHAR * URI_FUNC(ParseDecOctetOne)(
+        UriIp4Parser * parser, const URI_CHAR * first, const URI_CHAR * afterLast);
+static const URI_CHAR * URI_FUNC(ParseDecOctetTwo)(
+        UriIp4Parser * parser, const URI_CHAR * first, const URI_CHAR * afterLast);
+static const URI_CHAR * URI_FUNC(ParseDecOctetThree)(
+        UriIp4Parser * parser, const URI_CHAR * first, const URI_CHAR * afterLast);
+static const URI_CHAR * URI_FUNC(ParseDecOctetFour)(
+        UriIp4Parser * parser, const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /*
  * [ipFourAddress]->[decOctet]<.>[decOctet]<.>[decOctet]<.>[decOctet]
  */
-int URI_FUNC(ParseIpFourAddress)(unsigned char * octetOutput, const URI_CHAR * first,
-                                 const URI_CHAR * afterLast) {
+int URI_FUNC(ParseIpFourAddress)(
+        unsigned char * octetOutput, const URI_CHAR * first, const URI_CHAR * afterLast) {
     const URI_CHAR * after;
     UriIp4Parser parser;
 
@@ -147,9 +142,8 @@ int URI_FUNC(ParseIpFourAddress)(unsigned char * octetOutput, const URI_CHAR * f
  * [decOctet]-><8>[decOctetThree]
  * [decOctet]-><9>[decOctetThree]
  */
-static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctet)(UriIp4Parser * parser,
-                                                           const URI_CHAR * first,
-                                                           const URI_CHAR * afterLast) {
+static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctet)(
+        UriIp4Parser * parser, const URI_CHAR * first, const URI_CHAR * afterLast) {
     if (first >= afterLast) {
         return NULL;
     }
@@ -175,8 +169,8 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctet)(UriIp4Parser * parser
     case _UT('8'):
     case _UT('9'):
         uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
-        return (const URI_CHAR *)URI_FUNC(ParseDecOctetThree)(parser, first + 1,
-                                                              afterLast);
+        return (const URI_CHAR *)URI_FUNC(ParseDecOctetThree)(
+                parser, first + 1, afterLast);
 
     default:
         return NULL;
@@ -187,9 +181,8 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctet)(UriIp4Parser * parser
  * [decOctetOne]-><NULL>
  * [decOctetOne]->[DIGIT][decOctetThree]
  */
-static URI_INLINE const URI_CHAR *
-URI_FUNC(ParseDecOctetOne)(UriIp4Parser * parser, const URI_CHAR * first,
-                           const URI_CHAR * afterLast) {
+static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctetOne)(
+        UriIp4Parser * parser, const URI_CHAR * first, const URI_CHAR * afterLast) {
     if (first >= afterLast) {
         return afterLast;
     }
@@ -197,8 +190,8 @@ URI_FUNC(ParseDecOctetOne)(UriIp4Parser * parser, const URI_CHAR * first,
     switch (*first) {
     case URI_SET_DIGIT(_UT):
         uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
-        return (const URI_CHAR *)URI_FUNC(ParseDecOctetThree)(parser, first + 1,
-                                                              afterLast);
+        return (const URI_CHAR *)URI_FUNC(ParseDecOctetThree)(
+                parser, first + 1, afterLast);
 
     default:
         return first;
@@ -218,9 +211,8 @@ URI_FUNC(ParseDecOctetOne)(UriIp4Parser * parser, const URI_CHAR * first,
  * [decOctetTwo]-><8>
  * [decOctetTwo]-><9>
  */
-static URI_INLINE const URI_CHAR *
-URI_FUNC(ParseDecOctetTwo)(UriIp4Parser * parser, const URI_CHAR * first,
-                           const URI_CHAR * afterLast) {
+static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctetTwo)(
+        UriIp4Parser * parser, const URI_CHAR * first, const URI_CHAR * afterLast) {
     if (first >= afterLast) {
         return afterLast;
     }
@@ -232,13 +224,13 @@ URI_FUNC(ParseDecOctetTwo)(UriIp4Parser * parser, const URI_CHAR * first,
     case _UT('3'):
     case _UT('4'):
         uriPushToStack(parser, (unsigned char)(9 + *first - _UT('9')));
-        return (const URI_CHAR *)URI_FUNC(ParseDecOctetThree)(parser, first + 1,
-                                                              afterLast);
+        return (const URI_CHAR *)URI_FUNC(ParseDecOctetThree)(
+                parser, first + 1, afterLast);
 
     case _UT('5'):
         uriPushToStack(parser, 5);
-        return (const URI_CHAR *)URI_FUNC(ParseDecOctetFour)(parser, first + 1,
-                                                             afterLast);
+        return (const URI_CHAR *)URI_FUNC(ParseDecOctetFour)(
+                parser, first + 1, afterLast);
 
     case _UT('6'):
     case _UT('7'):
@@ -256,9 +248,8 @@ URI_FUNC(ParseDecOctetTwo)(UriIp4Parser * parser, const URI_CHAR * first,
  * [decOctetThree]-><NULL>
  * [decOctetThree]->[DIGIT]
  */
-static URI_INLINE const URI_CHAR *
-URI_FUNC(ParseDecOctetThree)(UriIp4Parser * parser, const URI_CHAR * first,
-                             const URI_CHAR * afterLast) {
+static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctetThree)(
+        UriIp4Parser * parser, const URI_CHAR * first, const URI_CHAR * afterLast) {
     if (first >= afterLast) {
         return afterLast;
     }
@@ -282,9 +273,8 @@ URI_FUNC(ParseDecOctetThree)(UriIp4Parser * parser, const URI_CHAR * first,
  * [decOctetFour]-><4>
  * [decOctetFour]-><5>
  */
-static URI_INLINE const URI_CHAR *
-URI_FUNC(ParseDecOctetFour)(UriIp4Parser * parser, const URI_CHAR * first,
-                            const URI_CHAR * afterLast) {
+static URI_INLINE const URI_CHAR * URI_FUNC(ParseDecOctetFour)(
+        UriIp4Parser * parser, const URI_CHAR * first, const URI_CHAR * afterLast) {
     if (first >= afterLast) {
         return afterLast;
     }

--- a/src/UriMemory.c
+++ b/src/UriMemory.c
@@ -93,18 +93,18 @@ static void * uriDefaultMalloc(UriMemoryManager * URI_UNUSED(memory), size_t siz
     return malloc(size);
 }
 
-static void * uriDefaultCalloc(UriMemoryManager * URI_UNUSED(memory), size_t nmemb,
-                               size_t size) {
+static void * uriDefaultCalloc(
+        UriMemoryManager * URI_UNUSED(memory), size_t nmemb, size_t size) {
     return calloc(nmemb, size);
 }
 
-static void * uriDefaultRealloc(UriMemoryManager * URI_UNUSED(memory), void * ptr,
-                                size_t size) {
+static void * uriDefaultRealloc(
+        UriMemoryManager * URI_UNUSED(memory), void * ptr, size_t size) {
     return realloc(ptr, size);
 }
 
-static void * uriDefaultReallocarray(UriMemoryManager * URI_UNUSED(memory), void * ptr,
-                                     size_t nmemb, size_t size) {
+static void * uriDefaultReallocarray(
+        UriMemoryManager * URI_UNUSED(memory), void * ptr, size_t nmemb, size_t size) {
 #ifdef HAVE_REALLOCARRAY
     return reallocarray(ptr, nmemb, size);
 #else
@@ -122,7 +122,7 @@ static void uriDefaultFree(UriMemoryManager * URI_UNUSED(memory), void * ptr) {
 
 UriBool uriMemoryManagerIsComplete(const UriMemoryManager * memory) {
     return (memory && memory->malloc && memory->calloc && memory->realloc
-            && memory->reallocarray && memory->free)
+                   && memory->reallocarray && memory->free)
                    ? URI_TRUE
                    : URI_FALSE;
 }
@@ -147,8 +147,8 @@ void * uriEmulateCalloc(UriMemoryManager * memory, size_t nmemb, size_t size) {
     return buffer;
 }
 
-void * uriEmulateReallocarray(UriMemoryManager * memory, void * ptr, size_t nmemb,
-                              size_t size) {
+void * uriEmulateReallocarray(
+        UriMemoryManager * memory, void * ptr, size_t nmemb, size_t size) {
     const size_t total_size = nmemb * size;
 
     if (memory == NULL) {
@@ -472,6 +472,6 @@ int uriTestMemoryManager(UriMemoryManager * memory) {
 }
 
 /*extern*/ UriMemoryManager defaultMemoryManager = {
-        uriDefaultMalloc,       uriDefaultCalloc, uriDefaultRealloc,
-        uriDefaultReallocarray, uriDefaultFree,   NULL /* userData */
+        uriDefaultMalloc, uriDefaultCalloc, uriDefaultRealloc, uriDefaultReallocarray,
+        uriDefaultFree, NULL /* userData */
 };

--- a/src/UriMemory.c
+++ b/src/UriMemory.c
@@ -123,8 +123,8 @@ static void uriDefaultFree(UriMemoryManager * URI_UNUSED(memory), void * ptr) {
 UriBool uriMemoryManagerIsComplete(const UriMemoryManager * memory) {
     return (memory && memory->malloc && memory->calloc && memory->realloc
             && memory->reallocarray && memory->free)
-               ? URI_TRUE
-               : URI_FALSE;
+                   ? URI_TRUE
+                   : URI_FALSE;
 }
 
 void * uriEmulateCalloc(UriMemoryManager * memory, size_t nmemb, size_t size) {
@@ -450,7 +450,7 @@ int uriTestMemoryManagerEx(UriMemoryManager * memory, UriBool challengeAlignment
             ptr[3] = 3.3L;
 
             long double * const ptrNew =
-                memory->realloc(memory, ptr, 8 * sizeof(long double));
+                    memory->realloc(memory, ptr, 8 * sizeof(long double));
             if (ptrNew != NULL) {
                 ptr = ptrNew;
                 ptr[4] = 4.4L;
@@ -472,6 +472,6 @@ int uriTestMemoryManager(UriMemoryManager * memory) {
 }
 
 /*extern*/ UriMemoryManager defaultMemoryManager = {
-    uriDefaultMalloc,       uriDefaultCalloc, uriDefaultRealloc,
-    uriDefaultReallocarray, uriDefaultFree,   NULL /* userData */
+        uriDefaultMalloc,       uriDefaultCalloc, uriDefaultRealloc,
+        uriDefaultReallocarray, uriDefaultFree,   NULL /* userData */
 };

--- a/src/UriNormalize.c
+++ b/src/UriNormalize.c
@@ -76,40 +76,35 @@
 #  include <stdint.h>  // SIZE_MAX
 
 static int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri, unsigned int inMask,
-                                           unsigned int * outMask,
-                                           UriMemoryManager * memory);
+        unsigned int * outMask, UriMemoryManager * memory);
 
 static UriBool URI_FUNC(MakeRangeOwner)(unsigned int * revertMask, unsigned int maskTest,
-                                        URI_TYPE(TextRange) * range,
-                                        UriMemoryManager * memory);
-static UriBool URI_FUNC(MakeOwnerEngine)(URI_TYPE(Uri) * uri, unsigned int * revertMask,
-                                         UriMemoryManager * memory);
+        URI_TYPE(TextRange) * range, UriMemoryManager * memory);
+static UriBool URI_FUNC(MakeOwnerEngine)(
+        URI_TYPE(Uri) * uri, unsigned int * revertMask, UriMemoryManager * memory);
 
-static void URI_FUNC(FixPercentEncodingInplace)(const URI_CHAR * first,
-                                                const URI_CHAR ** afterLast);
-static UriBool URI_FUNC(FixPercentEncodingMalloc)(const URI_CHAR ** first,
-                                                  const URI_CHAR ** afterLast,
-                                                  UriMemoryManager * memory);
+static void URI_FUNC(FixPercentEncodingInplace)(
+        const URI_CHAR * first, const URI_CHAR ** afterLast);
+static UriBool URI_FUNC(FixPercentEncodingMalloc)(
+        const URI_CHAR ** first, const URI_CHAR ** afterLast, UriMemoryManager * memory);
 static void URI_FUNC(FixPercentEncodingEngine)(const URI_CHAR * inFirst,
-                                               const URI_CHAR * inAfterLast,
-                                               const URI_CHAR * outFirst,
-                                               const URI_CHAR ** outAfterLast);
+        const URI_CHAR * inAfterLast, const URI_CHAR * outFirst,
+        const URI_CHAR ** outAfterLast);
 
-static UriBool URI_FUNC(ContainsUppercaseLetters)(const URI_CHAR * first,
-                                                  const URI_CHAR * afterLast);
-static UriBool URI_FUNC(ContainsUglyPercentEncoding)(const URI_CHAR * first,
-                                                     const URI_CHAR * afterLast);
+static UriBool URI_FUNC(ContainsUppercaseLetters)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
+static UriBool URI_FUNC(ContainsUglyPercentEncoding)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
 
-static void URI_FUNC(LowercaseInplace)(const URI_CHAR * first,
-                                       const URI_CHAR * afterLast);
-static void URI_FUNC(LowercaseInplaceExceptPercentEncoding)(const URI_CHAR * first,
-                                                            const URI_CHAR * afterLast);
-static UriBool URI_FUNC(LowercaseMalloc)(const URI_CHAR ** first,
-                                         const URI_CHAR ** afterLast,
-                                         UriMemoryManager * memory);
+static void URI_FUNC(LowercaseInplace)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
+static void URI_FUNC(LowercaseInplaceExceptPercentEncoding)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
+static UriBool URI_FUNC(LowercaseMalloc)(
+        const URI_CHAR ** first, const URI_CHAR ** afterLast, UriMemoryManager * memory);
 
-void URI_FUNC(PreventLeakage)(URI_TYPE(Uri) * uri, unsigned int revertMask,
-                              UriMemoryManager * memory) {
+void URI_FUNC(PreventLeakage)(
+        URI_TYPE(Uri) * uri, unsigned int revertMask, UriMemoryManager * memory) {
     if (revertMask & URI_NORMALIZE_SCHEME) {
         /* NOTE: A scheme cannot be the empty string
          *       so no need to compare .first with .afterLast, here. */
@@ -179,8 +174,8 @@ void URI_FUNC(PreventLeakage)(URI_TYPE(Uri) * uri, unsigned int revertMask,
     }
 }
 
-static URI_INLINE UriBool URI_FUNC(ContainsUppercaseLetters)(const URI_CHAR * first,
-                                                             const URI_CHAR * afterLast) {
+static URI_INLINE UriBool URI_FUNC(ContainsUppercaseLetters)(
+        const URI_CHAR * first, const URI_CHAR * afterLast) {
     if ((first != NULL) && (afterLast != NULL) && (afterLast > first)) {
         const URI_CHAR * i = first;
         for (; i < afterLast; i++) {
@@ -202,7 +197,7 @@ static URI_INLINE UriBool URI_FUNC(ContainsUglyPercentEncoding)(
                 /* 6.2.2.1 Case Normalization: *
                  * lowercase percent-encodings */
                 if (((i[1] >= _UT('a')) && (i[1] <= _UT('f')))
-                    || ((i[2] >= _UT('a')) && (i[2] <= _UT('f')))) {
+                        || ((i[2] >= _UT('a')) && (i[2] <= _UT('f')))) {
                     return URI_TRUE;
                 } else {
                     /* 6.2.2.2 Percent-Encoding Normalization: *
@@ -220,8 +215,8 @@ static URI_INLINE UriBool URI_FUNC(ContainsUglyPercentEncoding)(
     return URI_FALSE;
 }
 
-static URI_INLINE void URI_FUNC(LowercaseInplace)(const URI_CHAR * first,
-                                                  const URI_CHAR * afterLast) {
+static URI_INLINE void URI_FUNC(LowercaseInplace)(
+        const URI_CHAR * first, const URI_CHAR * afterLast) {
     if ((first != NULL) && (afterLast != NULL) && (afterLast > first)) {
         URI_CHAR * i = (URI_CHAR *)first;
         const int lowerUpperDiff = (_UT('a') - _UT('A'));
@@ -233,9 +228,8 @@ static URI_INLINE void URI_FUNC(LowercaseInplace)(const URI_CHAR * first,
     }
 }
 
-static URI_INLINE void
-URI_FUNC(LowercaseInplaceExceptPercentEncoding)(const URI_CHAR * first,
-                                                const URI_CHAR * afterLast) {
+static URI_INLINE void URI_FUNC(LowercaseInplaceExceptPercentEncoding)(
+        const URI_CHAR * first, const URI_CHAR * afterLast) {
     if ((first != NULL) && (afterLast != NULL) && (afterLast > first)) {
         URI_CHAR * i = (URI_CHAR *)first;
         const int lowerUpperDiff = (_UT('a') - _UT('A'));
@@ -252,15 +246,14 @@ URI_FUNC(LowercaseInplaceExceptPercentEncoding)(const URI_CHAR * first,
     }
 }
 
-static URI_INLINE UriBool URI_FUNC(LowercaseMalloc)(const URI_CHAR ** first,
-                                                    const URI_CHAR ** afterLast,
-                                                    UriMemoryManager * memory) {
+static URI_INLINE UriBool URI_FUNC(LowercaseMalloc)(
+        const URI_CHAR ** first, const URI_CHAR ** afterLast, UriMemoryManager * memory) {
     const int lowerUpperDiff = (_UT('a') - _UT('A'));
     URI_CHAR * buffer;
     size_t i = 0;
 
     if ((first == NULL) || (afterLast == NULL) || (*first == NULL)
-        || (*afterLast == NULL)) {
+            || (*afterLast == NULL)) {
         return URI_FALSE;
     }
 
@@ -293,10 +286,9 @@ static URI_INLINE UriBool URI_FUNC(LowercaseMalloc)(const URI_CHAR ** first,
 }
 
 /* NOTE: Implementation must stay inplace-compatible */
-static URI_INLINE void
-URI_FUNC(FixPercentEncodingEngine)(const URI_CHAR * inFirst, const URI_CHAR * inAfterLast,
-                                   const URI_CHAR * outFirst,
-                                   const URI_CHAR ** outAfterLast) {
+static URI_INLINE void URI_FUNC(FixPercentEncodingEngine)(const URI_CHAR * inFirst,
+        const URI_CHAR * inAfterLast, const URI_CHAR * outFirst,
+        const URI_CHAR ** outAfterLast) {
     URI_CHAR * write = (URI_CHAR *)outFirst;
     const size_t lenInChars = inAfterLast - inFirst;
     size_t i = 0;
@@ -339,8 +331,8 @@ URI_FUNC(FixPercentEncodingEngine)(const URI_CHAR * inFirst, const URI_CHAR * in
     *outAfterLast = write;
 }
 
-static URI_INLINE void URI_FUNC(FixPercentEncodingInplace)(const URI_CHAR * first,
-                                                           const URI_CHAR ** afterLast) {
+static URI_INLINE void URI_FUNC(FixPercentEncodingInplace)(
+        const URI_CHAR * first, const URI_CHAR ** afterLast) {
     /* Death checks */
     if ((first == NULL) || (afterLast == NULL) || (*afterLast == NULL)) {
         return;
@@ -350,14 +342,13 @@ static URI_INLINE void URI_FUNC(FixPercentEncodingInplace)(const URI_CHAR * firs
     URI_FUNC(FixPercentEncodingEngine)(first, *afterLast, first, afterLast);
 }
 
-static URI_INLINE UriBool URI_FUNC(FixPercentEncodingMalloc)(const URI_CHAR ** first,
-                                                             const URI_CHAR ** afterLast,
-                                                             UriMemoryManager * memory) {
+static URI_INLINE UriBool URI_FUNC(FixPercentEncodingMalloc)(
+        const URI_CHAR ** first, const URI_CHAR ** afterLast, UriMemoryManager * memory) {
     URI_CHAR * buffer;
 
     /* Death checks */
     if ((first == NULL) || (afterLast == NULL) || (*first == NULL)
-        || (*afterLast == NULL)) {
+            || (*afterLast == NULL)) {
         return URI_FALSE;
     }
 
@@ -385,11 +376,9 @@ static URI_INLINE UriBool URI_FUNC(FixPercentEncodingMalloc)(const URI_CHAR ** f
 }
 
 static URI_INLINE UriBool URI_FUNC(MakeRangeOwner)(unsigned int * revertMask,
-                                                   unsigned int maskTest,
-                                                   URI_TYPE(TextRange) * range,
-                                                   UriMemoryManager * memory) {
+        unsigned int maskTest, URI_TYPE(TextRange) * range, UriMemoryManager * memory) {
     if (((*revertMask & maskTest) == 0) && (range->first != NULL)
-        && (range->afterLast != NULL) && (range->afterLast > range->first)) {
+            && (range->afterLast != NULL) && (range->afterLast > range->first)) {
         if (URI_FUNC(CopyRange)(range, range, memory) == URI_FALSE) {
             return URI_FALSE;
         }
@@ -398,18 +387,17 @@ static URI_INLINE UriBool URI_FUNC(MakeRangeOwner)(unsigned int * revertMask,
     return URI_TRUE;
 }
 
-static URI_INLINE UriBool URI_FUNC(MakeOwnerEngine)(URI_TYPE(Uri) * uri,
-                                                    unsigned int * revertMask,
-                                                    UriMemoryManager * memory) {
+static URI_INLINE UriBool URI_FUNC(MakeOwnerEngine)(
+        URI_TYPE(Uri) * uri, unsigned int * revertMask, UriMemoryManager * memory) {
     URI_TYPE(PathSegment) * walker = uri->pathHead;
-    if (!URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_SCHEME, &(uri->scheme),
-                                  memory)
-        || !URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_USER_INFO,
-                                     &(uri->userInfo), memory)
-        || !URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_QUERY, &(uri->query),
-                                     memory)
-        || !URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_FRAGMENT, &(uri->fragment),
-                                     memory)) {
+    if (!URI_FUNC(MakeRangeOwner)(
+                revertMask, URI_NORMALIZE_SCHEME, &(uri->scheme), memory)
+            || !URI_FUNC(MakeRangeOwner)(
+                    revertMask, URI_NORMALIZE_USER_INFO, &(uri->userInfo), memory)
+            || !URI_FUNC(MakeRangeOwner)(
+                    revertMask, URI_NORMALIZE_QUERY, &(uri->query), memory)
+            || !URI_FUNC(MakeRangeOwner)(
+                    revertMask, URI_NORMALIZE_FRAGMENT, &(uri->fragment), memory)) {
         return URI_FALSE; /* Raises malloc error */
     }
 
@@ -418,15 +406,15 @@ static URI_INLINE UriBool URI_FUNC(MakeOwnerEngine)(URI_TYPE(Uri) * uri,
         if (uri->hostData.ipFuture.first != NULL) {
             /* IPvFuture */
             if (!URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_HOST,
-                                          &(uri->hostData.ipFuture), memory)) {
+                        &(uri->hostData.ipFuture), memory)) {
                 return URI_FALSE; /* Raises malloc error */
             }
             uri->hostText.first = uri->hostData.ipFuture.first;
             uri->hostText.afterLast = uri->hostData.ipFuture.afterLast;
         } else if (uri->hostText.first != NULL) {
             /* Regname */
-            if (!URI_FUNC(MakeRangeOwner)(revertMask, URI_NORMALIZE_HOST,
-                                          &(uri->hostText), memory)) {
+            if (!URI_FUNC(MakeRangeOwner)(
+                        revertMask, URI_NORMALIZE_HOST, &(uri->hostText), memory)) {
                 return URI_FALSE; /* Raises malloc error */
             }
         }
@@ -443,7 +431,7 @@ static URI_INLINE UriBool URI_FUNC(MakeOwnerEngine)(URI_TYPE(Uri) * uri,
                 while (ranger != walker) {
                     URI_TYPE(PathSegment) * const next = ranger->next;
                     if ((ranger->text.first != NULL) && (ranger->text.afterLast != NULL)
-                        && (ranger->text.afterLast > ranger->text.first)) {
+                            && (ranger->text.afterLast > ranger->text.first)) {
                         memory->free(memory, (URI_CHAR *)ranger->text.first);
                     }
                     memory->free(memory, ranger);
@@ -482,13 +470,14 @@ unsigned int URI_FUNC(NormalizeSyntaxMaskRequired)(const URI_TYPE(Uri) * uri) {
     return outMask;
 }
 
-int URI_FUNC(NormalizeSyntaxMaskRequiredEx)(const URI_TYPE(Uri) * uri,
-                                            unsigned int * outMask) {
+int URI_FUNC(NormalizeSyntaxMaskRequiredEx)(
+        const URI_TYPE(Uri) * uri, unsigned int * outMask) {
     UriMemoryManager * const memory = NULL; /* no use of memory manager */
 
 #  if defined(__GNUC__) \
           && ((__GNUC__ > 4) \
-              || ((__GNUC__ == 4) && defined(__GNUC_MINOR__) && (__GNUC_MINOR__ >= 2)))
+                  || ((__GNUC__ == 4) && defined(__GNUC_MINOR__) \
+                          && (__GNUC_MINOR__ >= 2)))
     /* Slower code that fixes a warning, not sure if this is a smart idea */
     URI_TYPE(Uri) writeableClone;
 #  endif
@@ -499,7 +488,8 @@ int URI_FUNC(NormalizeSyntaxMaskRequiredEx)(const URI_TYPE(Uri) * uri,
 
 #  if defined(__GNUC__) \
           && ((__GNUC__ > 4) \
-              || ((__GNUC__ == 4) && defined(__GNUC_MINOR__) && (__GNUC_MINOR__ >= 2)))
+                  || ((__GNUC__ == 4) && defined(__GNUC_MINOR__) \
+                          && (__GNUC_MINOR__ >= 2)))
     /* Slower code that fixes a warning, not sure if this is a smart idea */
     memcpy(&writeableClone, uri, 1 * sizeof(URI_TYPE(Uri)));
     URI_FUNC(NormalizeSyntaxEngine)(&writeableClone, 0, outMask, memory);
@@ -513,8 +503,8 @@ int URI_FUNC(NormalizeSyntaxEx)(URI_TYPE(Uri) * uri, unsigned int mask) {
     return URI_FUNC(NormalizeSyntaxExMm)(uri, mask, NULL);
 }
 
-int URI_FUNC(NormalizeSyntaxExMm)(URI_TYPE(Uri) * uri, unsigned int mask,
-                                  UriMemoryManager * memory) {
+int URI_FUNC(NormalizeSyntaxExMm)(
+        URI_TYPE(Uri) * uri, unsigned int mask, UriMemoryManager * memory) {
     URI_CHECK_MEMORY_MANAGER(memory); /* may return */
     return URI_FUNC(NormalizeSyntaxEngine)(uri, mask, NULL, memory);
 }
@@ -523,8 +513,8 @@ int URI_FUNC(NormalizeSyntax)(URI_TYPE(Uri) * uri) {
     return URI_FUNC(NormalizeSyntaxEx)(uri, (unsigned int)-1);
 }
 
-static const URI_CHAR * URI_FUNC(PastLeadingZeros)(const URI_CHAR * first,
-                                                   const URI_CHAR * afterLast) {
+static const URI_CHAR * URI_FUNC(PastLeadingZeros)(
+        const URI_CHAR * first, const URI_CHAR * afterLast) {
     assert(first != NULL);
     assert(afterLast != NULL);
     assert(first != afterLast);
@@ -547,8 +537,8 @@ static const URI_CHAR * URI_FUNC(PastLeadingZeros)(const URI_CHAR * first,
     return remainderFirst;
 }
 
-static void URI_FUNC(DropLeadingZerosInplace)(URI_CHAR * first,
-                                              const URI_CHAR ** afterLast) {
+static void URI_FUNC(DropLeadingZerosInplace)(
+        URI_CHAR * first, const URI_CHAR ** afterLast) {
     assert(first != NULL);
     assert(afterLast != NULL);
     assert(*afterLast != NULL);
@@ -567,8 +557,8 @@ static void URI_FUNC(DropLeadingZerosInplace)(URI_CHAR * first,
     }
 }
 
-static void URI_FUNC(AdvancePastLeadingZeros)(const URI_CHAR ** first,
-                                              const URI_CHAR * afterLast) {
+static void URI_FUNC(AdvancePastLeadingZeros)(
+        const URI_CHAR ** first, const URI_CHAR * afterLast) {
     assert(first != NULL);
     assert(*first != NULL);
     assert(afterLast != NULL);
@@ -584,9 +574,7 @@ static void URI_FUNC(AdvancePastLeadingZeros)(const URI_CHAR ** first,
 }
 
 static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
-                                                      unsigned int inMask,
-                                                      unsigned int * outMask,
-                                                      UriMemoryManager * memory) {
+        unsigned int inMask, unsigned int * outMask, UriMemoryManager * memory) {
     unsigned int revertMask = URI_NORMALIZED;
 
     /* Not just doing inspection? -> memory manager required! */
@@ -636,8 +624,8 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
             if (uri->owner) {
                 URI_FUNC(LowercaseInplace)(uri->scheme.first, uri->scheme.afterLast);
             } else {
-                if (!URI_FUNC(LowercaseMalloc)(&(uri->scheme.first),
-                                               &(uri->scheme.afterLast), memory)) {
+                if (!URI_FUNC(LowercaseMalloc)(
+                            &(uri->scheme.first), &(uri->scheme.afterLast), memory)) {
                     URI_FUNC(PreventLeakage)(uri, revertMask, memory);
                     return URI_ERROR_MALLOC;
                 }
@@ -651,11 +639,10 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
                 /* IPvFuture */
                 if (uri->owner) {
                     URI_FUNC(LowercaseInplace)(uri->hostData.ipFuture.first,
-                                               uri->hostData.ipFuture.afterLast);
+                            uri->hostData.ipFuture.afterLast);
                 } else {
                     if (!URI_FUNC(LowercaseMalloc)(&(uri->hostData.ipFuture.first),
-                                                   &(uri->hostData.ipFuture.afterLast),
-                                                   memory)) {
+                                &(uri->hostData.ipFuture.afterLast), memory)) {
                         URI_FUNC(PreventLeakage)(uri, revertMask, memory);
                         return URI_ERROR_MALLOC;
                     }
@@ -666,20 +653,19 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
             } else if ((uri->hostText.first != NULL) && (uri->hostData.ip4 == NULL)) {
                 /* Regname or IPv6 */
                 if (uri->owner) {
-                    URI_FUNC(FixPercentEncodingInplace)(uri->hostText.first,
-                                                        &(uri->hostText.afterLast));
+                    URI_FUNC(FixPercentEncodingInplace)(
+                            uri->hostText.first, &(uri->hostText.afterLast));
                 } else {
                     if (!URI_FUNC(FixPercentEncodingMalloc)(&(uri->hostText.first),
-                                                            &(uri->hostText.afterLast),
-                                                            memory)) {
+                                &(uri->hostText.afterLast), memory)) {
                         URI_FUNC(PreventLeakage)(uri, revertMask, memory);
                         return URI_ERROR_MALLOC;
                     }
                     revertMask |= URI_NORMALIZE_HOST;
                 }
 
-                URI_FUNC(LowercaseInplaceExceptPercentEncoding)(uri->hostText.first,
-                                                                uri->hostText.afterLast);
+                URI_FUNC(LowercaseInplaceExceptPercentEncoding)(
+                        uri->hostText.first, uri->hostText.afterLast);
             }
         }
     }
@@ -699,11 +685,11 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
         /* Normalize the port, i.e. drop leading zeros (except for string "0") */
         if ((inMask & URI_NORMALIZE_PORT) && (uri->portText.first != NULL)) {
             if (uri->owner) {
-                URI_FUNC(DropLeadingZerosInplace)((URI_CHAR *)uri->portText.first,
-                                                  &(uri->portText.afterLast));
+                URI_FUNC(DropLeadingZerosInplace)(
+                        (URI_CHAR *)uri->portText.first, &(uri->portText.afterLast));
             } else {
-                URI_FUNC(AdvancePastLeadingZeros)(&(uri->portText.first),
-                                                  uri->portText.afterLast);
+                URI_FUNC(AdvancePastLeadingZeros)(
+                        &(uri->portText.first), uri->portText.afterLast);
             }
         }
     }
@@ -718,8 +704,8 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
     } else {
         if ((inMask & URI_NORMALIZE_USER_INFO) && (uri->userInfo.first != NULL)) {
             if (uri->owner) {
-                URI_FUNC(FixPercentEncodingInplace)(uri->userInfo.first,
-                                                    &(uri->userInfo.afterLast));
+                URI_FUNC(FixPercentEncodingInplace)(
+                        uri->userInfo.first, &(uri->userInfo.afterLast));
             } else {
                 if (!URI_FUNC(FixPercentEncodingMalloc)(
                             &(uri->userInfo.first), &(uri->userInfo.afterLast), memory)) {
@@ -738,10 +724,10 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
             const URI_CHAR * const first = walker->text.first;
             const URI_CHAR * const afterLast = walker->text.afterLast;
             if ((first != NULL) && (afterLast != NULL) && (afterLast > first)
-                && ((((afterLast - first) == 1) && (first[0] == _UT('.')))
-                    || (((afterLast - first) == 2) && (first[0] == _UT('.'))
-                        && (first[1] == _UT('.')))
-                    || URI_FUNC(ContainsUglyPercentEncoding)(first, afterLast))) {
+                    && ((((afterLast - first) == 1) && (first[0] == _UT('.')))
+                            || (((afterLast - first) == 2) && (first[0] == _UT('.'))
+                                    && (first[1] == _UT('.')))
+                            || URI_FUNC(ContainsUglyPercentEncoding)(first, afterLast))) {
                 *outMask |= URI_NORMALIZE_PATH;
                 break;
             }
@@ -757,8 +743,8 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
         walker = uri->pathHead;
         if (uri->owner) {
             while (walker != NULL) {
-                URI_FUNC(FixPercentEncodingInplace)(walker->text.first,
-                                                    &(walker->text.afterLast));
+                URI_FUNC(FixPercentEncodingInplace)(
+                        walker->text.first, &(walker->text.afterLast));
                 walker = walker->next;
             }
         } else {
@@ -774,8 +760,7 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
         }
 
         /* 6.2.2.3 Path Segment Normalization */
-        if (!URI_FUNC(RemoveDotSegmentsEx)(
-                    uri, relative,
+        if (!URI_FUNC(RemoveDotSegmentsEx)(uri, relative,
                     (uri->owner == URI_TRUE) || ((revertMask & URI_NORMALIZE_PATH) != 0),
                     memory)) {
             URI_FUNC(PreventLeakage)(uri, revertMask, memory);
@@ -801,8 +786,8 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
         /* Query */
         if ((inMask & URI_NORMALIZE_QUERY) && (uri->query.first != NULL)) {
             if (uri->owner) {
-                URI_FUNC(FixPercentEncodingInplace)(uri->query.first,
-                                                    &(uri->query.afterLast));
+                URI_FUNC(FixPercentEncodingInplace)(
+                        uri->query.first, &(uri->query.afterLast));
             } else {
                 if (!URI_FUNC(FixPercentEncodingMalloc)(
                             &(uri->query.first), &(uri->query.afterLast), memory)) {
@@ -816,8 +801,8 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
         /* Fragment */
         if ((inMask & URI_NORMALIZE_FRAGMENT) && (uri->fragment.first != NULL)) {
             if (uri->owner) {
-                URI_FUNC(FixPercentEncodingInplace)(uri->fragment.first,
-                                                    &(uri->fragment.afterLast));
+                URI_FUNC(FixPercentEncodingInplace)(
+                        uri->fragment.first, &(uri->fragment.afterLast));
             } else {
                 if (!URI_FUNC(FixPercentEncodingMalloc)(
                             &(uri->fragment.first), &(uri->fragment.afterLast), memory)) {

--- a/src/UriNormalize.c
+++ b/src/UriNormalize.c
@@ -194,7 +194,7 @@ static URI_INLINE UriBool URI_FUNC(ContainsUppercaseLetters)(const URI_CHAR * fi
 }
 
 static URI_INLINE UriBool URI_FUNC(ContainsUglyPercentEncoding)(
-    const URI_CHAR * first, const URI_CHAR * afterLast) {
+        const URI_CHAR * first, const URI_CHAR * afterLast) {
     if ((first != NULL) && (afterLast != NULL) && (afterLast > first)) {
         const URI_CHAR * i = first;
         for (; i + 2 < afterLast; i++) {
@@ -487,8 +487,8 @@ int URI_FUNC(NormalizeSyntaxMaskRequiredEx)(const URI_TYPE(Uri) * uri,
     UriMemoryManager * const memory = NULL; /* no use of memory manager */
 
 #  if defined(__GNUC__) \
-      && ((__GNUC__ > 4) \
-          || ((__GNUC__ == 4) && defined(__GNUC_MINOR__) && (__GNUC_MINOR__ >= 2)))
+          && ((__GNUC__ > 4) \
+              || ((__GNUC__ == 4) && defined(__GNUC_MINOR__) && (__GNUC_MINOR__ >= 2)))
     /* Slower code that fixes a warning, not sure if this is a smart idea */
     URI_TYPE(Uri) writeableClone;
 #  endif
@@ -498,8 +498,8 @@ int URI_FUNC(NormalizeSyntaxMaskRequiredEx)(const URI_TYPE(Uri) * uri,
     }
 
 #  if defined(__GNUC__) \
-      && ((__GNUC__ > 4) \
-          || ((__GNUC__ == 4) && defined(__GNUC_MINOR__) && (__GNUC_MINOR__ >= 2)))
+          && ((__GNUC__ > 4) \
+              || ((__GNUC__ == 4) && defined(__GNUC_MINOR__) && (__GNUC_MINOR__ >= 2)))
     /* Slower code that fixes a warning, not sure if this is a smart idea */
     memcpy(&writeableClone, uri, 1 * sizeof(URI_TYPE(Uri)));
     URI_FUNC(NormalizeSyntaxEngine)(&writeableClone, 0, outMask, memory);
@@ -613,10 +613,10 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
 
     /* Scheme, host */
     if (outMask != NULL) {
-        const UriBool normalizeScheme =
-            URI_FUNC(ContainsUppercaseLetters)(uri->scheme.first, uri->scheme.afterLast);
+        const UriBool normalizeScheme = URI_FUNC(ContainsUppercaseLetters)(
+                uri->scheme.first, uri->scheme.afterLast);
         const UriBool normalizeHostCase = URI_FUNC(ContainsUppercaseLetters)(
-            uri->hostText.first, uri->hostText.afterLast);
+                uri->hostText.first, uri->hostText.afterLast);
         if (normalizeScheme) {
             *outMask |= URI_NORMALIZE_SCHEME;
         }
@@ -625,7 +625,7 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
             *outMask |= URI_NORMALIZE_HOST;
         } else {
             const UriBool normalizeHostPrecent = URI_FUNC(ContainsUglyPercentEncoding)(
-                uri->hostText.first, uri->hostText.afterLast);
+                    uri->hostText.first, uri->hostText.afterLast);
             if (normalizeHostPrecent) {
                 *outMask |= URI_NORMALIZE_HOST;
             }
@@ -669,8 +669,9 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
                     URI_FUNC(FixPercentEncodingInplace)(uri->hostText.first,
                                                         &(uri->hostText.afterLast));
                 } else {
-                    if (!URI_FUNC(FixPercentEncodingMalloc)(
-                            &(uri->hostText.first), &(uri->hostText.afterLast), memory)) {
+                    if (!URI_FUNC(FixPercentEncodingMalloc)(&(uri->hostText.first),
+                                                            &(uri->hostText.afterLast),
+                                                            memory)) {
                         URI_FUNC(PreventLeakage)(uri, revertMask, memory);
                         return URI_ERROR_MALLOC;
                     }
@@ -710,7 +711,7 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
     /* User info */
     if (outMask != NULL) {
         const UriBool normalizeUserInfo = URI_FUNC(ContainsUglyPercentEncoding)(
-            uri->userInfo.first, uri->userInfo.afterLast);
+                uri->userInfo.first, uri->userInfo.afterLast);
         if (normalizeUserInfo) {
             *outMask |= URI_NORMALIZE_USER_INFO;
         }
@@ -721,7 +722,7 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
                                                     &(uri->userInfo.afterLast));
             } else {
                 if (!URI_FUNC(FixPercentEncodingMalloc)(
-                        &(uri->userInfo.first), &(uri->userInfo.afterLast), memory)) {
+                            &(uri->userInfo.first), &(uri->userInfo.afterLast), memory)) {
                     URI_FUNC(PreventLeakage)(uri, revertMask, memory);
                     return URI_ERROR_MALLOC;
                 }
@@ -748,8 +749,9 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
         }
     } else if (inMask & URI_NORMALIZE_PATH) {
         URI_TYPE(PathSegment) * walker;
-        const UriBool relative =
-            ((uri->scheme.first == NULL) && !uri->absolutePath) ? URI_TRUE : URI_FALSE;
+        const UriBool relative = ((uri->scheme.first == NULL) && !uri->absolutePath)
+                                         ? URI_TRUE
+                                         : URI_FALSE;
 
         /* Fix percent-encoding for each segment */
         walker = uri->pathHead;
@@ -762,7 +764,7 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
         } else {
             while (walker != NULL) {
                 if (!URI_FUNC(FixPercentEncodingMalloc)(
-                        &(walker->text.first), &(walker->text.afterLast), memory)) {
+                            &(walker->text.first), &(walker->text.afterLast), memory)) {
                     URI_FUNC(PreventLeakage)(uri, revertMask, memory);
                     return URI_ERROR_MALLOC;
                 }
@@ -773,9 +775,9 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
 
         /* 6.2.2.3 Path Segment Normalization */
         if (!URI_FUNC(RemoveDotSegmentsEx)(
-                uri, relative,
-                (uri->owner == URI_TRUE) || ((revertMask & URI_NORMALIZE_PATH) != 0),
-                memory)) {
+                    uri, relative,
+                    (uri->owner == URI_TRUE) || ((revertMask & URI_NORMALIZE_PATH) != 0),
+                    memory)) {
             URI_FUNC(PreventLeakage)(uri, revertMask, memory);
             return URI_ERROR_MALLOC;
         }
@@ -784,10 +786,10 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
 
     /* Query, fragment */
     if (outMask != NULL) {
-        const UriBool normalizeQuery =
-            URI_FUNC(ContainsUglyPercentEncoding)(uri->query.first, uri->query.afterLast);
+        const UriBool normalizeQuery = URI_FUNC(ContainsUglyPercentEncoding)(
+                uri->query.first, uri->query.afterLast);
         const UriBool normalizeFragment = URI_FUNC(ContainsUglyPercentEncoding)(
-            uri->fragment.first, uri->fragment.afterLast);
+                uri->fragment.first, uri->fragment.afterLast);
         if (normalizeQuery) {
             *outMask |= URI_NORMALIZE_QUERY;
         }
@@ -803,7 +805,7 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
                                                     &(uri->query.afterLast));
             } else {
                 if (!URI_FUNC(FixPercentEncodingMalloc)(
-                        &(uri->query.first), &(uri->query.afterLast), memory)) {
+                            &(uri->query.first), &(uri->query.afterLast), memory)) {
                     URI_FUNC(PreventLeakage)(uri, revertMask, memory);
                     return URI_ERROR_MALLOC;
                 }
@@ -818,7 +820,7 @@ static URI_INLINE int URI_FUNC(NormalizeSyntaxEngine)(URI_TYPE(Uri) * uri,
                                                     &(uri->fragment.afterLast));
             } else {
                 if (!URI_FUNC(FixPercentEncodingMalloc)(
-                        &(uri->fragment.first), &(uri->fragment.afterLast), memory)) {
+                            &(uri->fragment.first), &(uri->fragment.afterLast), memory)) {
                     URI_FUNC(PreventLeakage)(uri, revertMask, memory);
                     return URI_ERROR_MALLOC;
                 }

--- a/src/UriNormalize.h
+++ b/src/UriNormalize.h
@@ -39,8 +39,8 @@
  */
 
 #if (defined(URI_PASS_ANSI) && !defined(URI_NORMALIZE_H_ANSI)) \
-    || (defined(URI_PASS_UNICODE) && !defined(URI_NORMALIZE_H_UNICODE)) \
-    || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+        || (defined(URI_PASS_UNICODE) && !defined(URI_NORMALIZE_H_UNICODE)) \
+        || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* What encodings are enabled? */
 #  include <uriparser/UriDefsConfig.h>
 #  if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
@@ -58,8 +58,8 @@
 /* Only one pass for each encoding */
 #  elif (defined(URI_PASS_ANSI) && !defined(URI_NORMALIZE_H_ANSI) \
          && defined(URI_ENABLE_ANSI)) \
-      || (defined(URI_PASS_UNICODE) && !defined(URI_NORMALIZE_H_UNICODE) \
-          && defined(URI_ENABLE_UNICODE))
+          || (defined(URI_PASS_UNICODE) && !defined(URI_NORMALIZE_H_UNICODE) \
+              && defined(URI_ENABLE_UNICODE))
 #    ifdef URI_PASS_ANSI
 #      define URI_NORMALIZE_H_ANSI 1
 #      include <uriparser/UriDefsAnsi.h>

--- a/src/UriNormalize.h
+++ b/src/UriNormalize.h
@@ -57,9 +57,9 @@
 #    endif
 /* Only one pass for each encoding */
 #  elif (defined(URI_PASS_ANSI) && !defined(URI_NORMALIZE_H_ANSI) \
-         && defined(URI_ENABLE_ANSI)) \
+          && defined(URI_ENABLE_ANSI)) \
           || (defined(URI_PASS_UNICODE) && !defined(URI_NORMALIZE_H_UNICODE) \
-              && defined(URI_ENABLE_UNICODE))
+                  && defined(URI_ENABLE_UNICODE))
 #    ifdef URI_PASS_ANSI
 #      define URI_NORMALIZE_H_ANSI 1
 #      include <uriparser/UriDefsAnsi.h>
@@ -68,8 +68,8 @@
 #      include <uriparser/UriDefsUnicode.h>
 #    endif
 
-void URI_FUNC(PreventLeakage)(URI_TYPE(Uri) * uri, unsigned int revertMask,
-                              UriMemoryManager * memory);
+void URI_FUNC(PreventLeakage)(
+        URI_TYPE(Uri) * uri, unsigned int revertMask, UriMemoryManager * memory);
 
 #  endif
 #endif

--- a/src/UriParse.c
+++ b/src/UriParse.c
@@ -249,7 +249,7 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseAuthority)(URI_TYPE(ParserState
     switch (*first) {
     case _UT('['): {
         const URI_CHAR * const afterIpLit2 =
-            URI_FUNC(ParseIpLit2)(state, first + 1, afterLast, memory);
+                URI_FUNC(ParseIpLit2)(state, first + 1, afterLast, memory);
         if (afterIpLit2 == NULL) {
             return NULL;
         }
@@ -408,7 +408,7 @@ static const URI_CHAR * URI_FUNC(ParseIpFuture)(URI_TYPE(ParserState) * state,
     case URI_SET_HEXDIG(_UT): {
         const URI_CHAR * afterIpFutLoop;
         const URI_CHAR * const afterHexZero =
-            URI_FUNC(ParseHexZero)(first + 2, afterLast);
+                URI_FUNC(ParseHexZero)(first + 2, afterLast);
         if (afterHexZero == NULL) {
             return NULL;
         }
@@ -423,7 +423,7 @@ static const URI_CHAR * URI_FUNC(ParseIpFuture)(URI_TYPE(ParserState) * state,
         state->uri->hostText.first = first; /* HOST BEGIN */
         state->uri->hostData.ipFuture.first = first; /* IPFUTURE BEGIN */
         afterIpFutLoop =
-            URI_FUNC(ParseIpFutLoop)(state, afterHexZero + 1, afterLast, memory);
+                URI_FUNC(ParseIpFutLoop)(state, afterHexZero + 1, afterLast, memory);
         if (afterIpFutLoop == NULL) {
             return NULL;
         }
@@ -463,7 +463,7 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseIpLit2)(URI_TYPE(ParserState) *
     case _UT('v'):
     case _UT('V'): {
         const URI_CHAR * const afterIpFuture =
-            URI_FUNC(ParseIpFuture)(state, first, afterLast, memory);
+                URI_FUNC(ParseIpFuture)(state, first, afterLast, memory);
         if (afterIpFuture == NULL) {
             return NULL;
         }
@@ -482,7 +482,7 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseIpLit2)(URI_TYPE(ParserState) *
     case _UT(']'):
     case URI_SET_HEXDIG(_UT):
         state->uri->hostData.ip6 = memory->malloc(
-            memory, 1 * sizeof(UriIp6)); /* Freed when stopping on parse error */
+                memory, 1 * sizeof(UriIp6)); /* Freed when stopping on parse error */
         if (state->uri->hostData.ip6 == NULL) {
             URI_FUNC(StopMalloc)(state, memory);
             return NULL;
@@ -542,7 +542,7 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
                         return NULL;
                     } else if ((digitCount == 3)
                                && (100 * digitHistory[0] + 10 * digitHistory[1]
-                                       + digitHistory[2]
+                                           + digitHistory[2]
                                    > 255)) {
                         /* Octet value too large */
                         if (digitHistory[0] > 2) {
@@ -557,7 +557,7 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
 
                     /* Copy IPv4 octet */
                     state->uri->hostData.ip6->data[16 - 4 + ip4OctetsDone] =
-                        uriGetOctetValue(digitHistory, digitCount);
+                            uriGetOctetValue(digitHistory, digitCount);
                     digitCount = 0;
                     ip4OctetsDone++;
                     break;
@@ -574,7 +574,7 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
                         return NULL;
                     } else if ((digitCount == 3)
                                && (100 * digitHistory[0] + 10 * digitHistory[1]
-                                       + digitHistory[2]
+                                           + digitHistory[2]
                                    > 255)) {
                         /* Octet value too large */
                         if (digitHistory[0] > 2) {
@@ -591,12 +591,12 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
 
                     /* Copy missing quads right before IPv4 */
                     memcpy(state->uri->hostData.ip6->data + 16 - 4
-                               - 2 * quadsAfterZipperCount,
+                                   - 2 * quadsAfterZipperCount,
                            quadsAfterZipper, 2 * quadsAfterZipperCount);
 
                     /* Copy last IPv4 octet */
                     state->uri->hostData.ip6->data[16 - 4 + 3] =
-                        uriGetOctetValue(digitHistory, digitCount);
+                            uriGetOctetValue(digitHistory, digitCount);
 
                     return first + 1;
 
@@ -653,12 +653,12 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
                         if (zipperEver) {
                             uriWriteQuadToDoubleByte(digitHistory, digitCount,
                                                      quadsAfterZipper
-                                                         + 2 * quadsAfterZipperCount);
+                                                             + 2 * quadsAfterZipperCount);
                             quadsAfterZipperCount++;
                         } else {
                             uriWriteQuadToDoubleByte(digitHistory, digitCount,
                                                      state->uri->hostData.ip6->data
-                                                         + 2 * quadsDone);
+                                                             + 2 * quadsDone);
                         }
                         quadsDone++;
                         digitCount = 0;
@@ -723,7 +723,7 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
                         return NULL;
                     } else if ((digitCount == 3)
                                && (100 * digitHistory[0] + 10 * digitHistory[1]
-                                       + digitHistory[2]
+                                           + digitHistory[2]
                                    > 255)) {
                         /* Octet value too large */
                         if (digitHistory[0] > 2) {
@@ -738,7 +738,7 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
 
                     /* Copy first IPv4 octet */
                     state->uri->hostData.ip6->data[16 - 4] =
-                        uriGetOctetValue(digitHistory, digitCount);
+                            uriGetOctetValue(digitHistory, digitCount);
                     digitCount = 0;
 
                     /* Switch over to IPv4 loop */
@@ -762,12 +762,12 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
                             }
                             uriWriteQuadToDoubleByte(digitHistory, digitCount,
                                                      quadsAfterZipper
-                                                         + 2 * quadsAfterZipperCount);
+                                                             + 2 * quadsAfterZipperCount);
                             quadsAfterZipperCount++;
                         } else {
                             uriWriteQuadToDoubleByte(digitHistory, digitCount,
                                                      state->uri->hostData.ip6->data
-                                                         + 2 * quadsDone);
+                                                             + 2 * quadsDone);
                         }
                         /*
                         quadsDone++;
@@ -777,7 +777,7 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
 
                     /* Copy missing quads to the end */
                     memcpy(state->uri->hostData.ip6->data + 16
-                               - 2 * quadsAfterZipperCount,
+                                   - 2 * quadsAfterZipperCount,
                            quadsAfterZipper, 2 * quadsAfterZipperCount);
 
                     state->uri->hostText.afterLast = first; /* HOST END */
@@ -824,7 +824,7 @@ tail_call:
     switch (*first) {
     case _UT('%'): {
         const URI_CHAR * const afterPctEncoded =
-            URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
+                URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
         if (afterPctEncoded == NULL) {
             return NULL;
         }
@@ -857,7 +857,7 @@ tail_call:
             return NULL;
         }
         afterZeroMoreSlashSegs =
-            URI_FUNC(ParseZeroMoreSlashSegs)(state, afterSegment, afterLast, memory);
+                URI_FUNC(ParseZeroMoreSlashSegs)(state, afterSegment, afterLast, memory);
         if (afterZeroMoreSlashSegs == NULL) {
             return NULL;
         }
@@ -891,7 +891,7 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseOwnHost)(URI_TYPE(ParserState) 
     switch (*first) {
     case _UT('['): {
         const URI_CHAR * const afterIpLit2 =
-            URI_FUNC(ParseIpLit2)(state, first + 1, afterLast, memory);
+                URI_FUNC(ParseIpLit2)(state, first + 1, afterLast, memory);
         if (afterIpLit2 == NULL) {
             return NULL;
         }
@@ -911,7 +911,7 @@ static URI_INLINE UriBool URI_FUNC(OnExitOwnHost2)(URI_TYPE(ParserState) * state
 
     /* Valid IPv4 or just a regname? */
     state->uri->hostData.ip4 = memory->malloc(
-        memory, 1 * sizeof(UriIp4)); /* Freed when stopping on parse error */
+            memory, 1 * sizeof(UriIp4)); /* Freed when stopping on parse error */
     if (state->uri->hostData.ip4 == NULL) {
         return URI_FALSE; /* Raises malloc error */
     }
@@ -947,7 +947,7 @@ tail_call:
     case URI_SET_SUB_DELIMS(_UT):
     case URI_SET_UNRESERVED(_UT): {
         const URI_CHAR * const afterPctSubUnres =
-            URI_FUNC(ParsePctSubUnres)(state, first, afterLast, memory);
+                URI_FUNC(ParsePctSubUnres)(state, first, afterLast, memory);
         if (afterPctSubUnres == NULL) {
             return NULL;
         }
@@ -968,13 +968,13 @@ static URI_INLINE UriBool URI_FUNC(OnExitOwnHostUserInfo)(URI_TYPE(ParserState) 
                                                           const URI_CHAR * first,
                                                           UriMemoryManager * memory) {
     state->uri->hostText.first =
-        state->uri->userInfo.first; /* Host instead of userInfo, update */
+            state->uri->userInfo.first; /* Host instead of userInfo, update */
     state->uri->userInfo.first = NULL; /* Not a userInfo, reset */
     state->uri->hostText.afterLast = first; /* HOST END */
 
     /* Valid IPv4 or just a regname? */
     state->uri->hostData.ip4 = memory->malloc(
-        memory, 1 * sizeof(UriIp4)); /* Freed when stopping on parse error */
+            memory, 1 * sizeof(UriIp4)); /* Freed when stopping on parse error */
     if (state->uri->hostData.ip4 == NULL) {
         return URI_FALSE; /* Raises malloc error */
     }
@@ -1008,7 +1008,7 @@ static const URI_CHAR * URI_FUNC(ParseOwnHostUserInfoNz)(URI_TYPE(ParserState) *
         case URI_SET_SUB_DELIMS(_UT):
         case URI_SET_UNRESERVED(_UT): {
             const URI_CHAR * const afterPctSubUnres =
-                URI_FUNC(ParsePctSubUnres)(state, first, afterLast, memory);
+                    URI_FUNC(ParsePctSubUnres)(state, first, afterLast, memory);
             if (afterPctSubUnres == NULL) {
                 return NULL;
             }
@@ -1057,13 +1057,13 @@ static URI_INLINE UriBool URI_FUNC(OnExitOwnPortUserInfo)(URI_TYPE(ParserState) 
                                                           const URI_CHAR * first,
                                                           UriMemoryManager * memory) {
     state->uri->hostText.first =
-        state->uri->userInfo.first; /* Host instead of userInfo, update */
+            state->uri->userInfo.first; /* Host instead of userInfo, update */
     state->uri->userInfo.first = NULL; /* Not a userInfo, reset */
     state->uri->portText.afterLast = first; /* PORT END */
 
     /* Valid IPv4 or just a regname? */
     state->uri->hostData.ip4 = memory->malloc(
-        memory, 1 * sizeof(UriIp4)); /* Freed when stopping on parse error */
+            memory, 1 * sizeof(UriIp4)); /* Freed when stopping on parse error */
     if (state->uri->hostData.ip4 == NULL) {
         return URI_FALSE; /* Raises malloc error */
     }
@@ -1124,7 +1124,7 @@ tail_call:
     case _UT('%'):
         state->uri->portText.first = NULL; /* Not a port, reset */
         const URI_CHAR * const afterPct =
-            URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
+                URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
         if (afterPct == NULL) {
             return NULL;
         }
@@ -1166,7 +1166,7 @@ tail_call:
     case URI_SET_SUB_DELIMS(_UT):
     case URI_SET_UNRESERVED(_UT): {
         const URI_CHAR * const afterPctSubUnres =
-            URI_FUNC(ParsePctSubUnres)(state, first, afterLast, memory);
+                URI_FUNC(ParsePctSubUnres)(state, first, afterLast, memory);
         if (afterPctSubUnres == NULL) {
             return NULL;
         }
@@ -1209,13 +1209,13 @@ URI_FUNC(ParsePartHelperTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * fir
     switch (*first) {
     case _UT('/'): {
         const URI_CHAR * const afterAuthority =
-            URI_FUNC(ParseAuthority)(state, first + 1, afterLast, memory);
+                URI_FUNC(ParseAuthority)(state, first + 1, afterLast, memory);
         const URI_CHAR * afterPathAbsEmpty;
         if (afterAuthority == NULL) {
             return NULL;
         }
         afterPathAbsEmpty =
-            URI_FUNC(ParsePathAbsEmpty)(state, afterAuthority, afterLast, memory);
+                URI_FUNC(ParsePathAbsEmpty)(state, afterAuthority, afterLast, memory);
 
         URI_FUNC(FixEmptyTrailSegment)(state->uri, memory);
 
@@ -1244,7 +1244,7 @@ tail_call:
     switch (*first) {
     case _UT('/'): {
         const URI_CHAR * const afterSegment =
-            URI_FUNC(ParseSegment)(state, first + 1, afterLast, memory);
+                URI_FUNC(ParseSegment)(state, first + 1, afterLast, memory);
         if (afterSegment == NULL) {
             return NULL;
         }
@@ -1276,7 +1276,7 @@ URI_FUNC(ParsePathAbsNoLeadSlash)(URI_TYPE(ParserState) * state, const URI_CHAR 
     switch (*first) {
     case URI_SET_PCHAR(_UT): {
         const URI_CHAR * const afterSegmentNz =
-            URI_FUNC(ParseSegmentNz)(state, first, afterLast, memory);
+                URI_FUNC(ParseSegmentNz)(state, first, afterLast, memory);
         if (afterSegmentNz == NULL) {
             return NULL;
         }
@@ -1300,7 +1300,7 @@ static URI_INLINE const URI_CHAR *
 URI_FUNC(ParsePathRootless)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
                             const URI_CHAR * afterLast, UriMemoryManager * memory) {
     const URI_CHAR * const afterSegmentNz =
-        URI_FUNC(ParseSegmentNz)(state, first, afterLast, memory);
+            URI_FUNC(ParseSegmentNz)(state, first, afterLast, memory);
     if (afterSegmentNz == NULL) {
         return NULL;
     } else {
@@ -1462,7 +1462,7 @@ tail_call:
     switch (*first) {
     case URI_SET_PCHAR(_UT): {
         const URI_CHAR * const afterPchar =
-            URI_FUNC(ParsePchar)(state, first, afterLast, memory);
+                URI_FUNC(ParsePchar)(state, first, afterLast, memory);
         if (afterPchar == NULL) {
             return NULL;
         }
@@ -1496,7 +1496,7 @@ tail_call:
     switch (*first) {
     case URI_SET_PCHAR(_UT): {
         const URI_CHAR * const afterPchar =
-            URI_FUNC(ParsePchar)(state, first, afterLast, memory);
+                URI_FUNC(ParsePchar)(state, first, afterLast, memory);
         if (afterPchar == NULL) {
             return NULL;
         }
@@ -1517,15 +1517,16 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseSegmentNz)(URI_TYPE(ParserState
                                                             const URI_CHAR * afterLast,
                                                             UriMemoryManager * memory) {
     const URI_CHAR * const afterPchar =
-        URI_FUNC(ParsePchar)(state, first, afterLast, memory);
+            URI_FUNC(ParsePchar)(state, first, afterLast, memory);
     if (afterPchar == NULL) {
         return NULL;
     }
     return URI_FUNC(ParseSegment)(state, afterPchar, afterLast, memory);
 }
 
-static URI_INLINE UriBool URI_FUNC(OnExitSegmentNzNcOrScheme2)(
-    URI_TYPE(ParserState) * state, const URI_CHAR * first, UriMemoryManager * memory) {
+static URI_INLINE UriBool
+URI_FUNC(OnExitSegmentNzNcOrScheme2)(URI_TYPE(ParserState) * state,
+                                     const URI_CHAR * first, UriMemoryManager * memory) {
     if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first,
                                    memory)) { /* SEGMENT BOTH */
         return URI_FALSE; /* Raises malloc error*/
@@ -1582,7 +1583,7 @@ tail_call:
 
     case _UT('%'): {
         const URI_CHAR * const afterPctEncoded =
-            URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
+                URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
         if (afterPctEncoded == NULL) {
             return NULL;
         }
@@ -1608,7 +1609,7 @@ tail_call:
     case _UT('/'): {
         const URI_CHAR * afterZeroMoreSlashSegs;
         const URI_CHAR * const afterSegment =
-            URI_FUNC(ParseSegment)(state, first + 1, afterLast, memory);
+                URI_FUNC(ParseSegment)(state, first + 1, afterLast, memory);
         if (afterSegment == NULL) {
             return NULL;
         }
@@ -1624,7 +1625,7 @@ tail_call:
             return NULL;
         }
         afterZeroMoreSlashSegs =
-            URI_FUNC(ParseZeroMoreSlashSegs)(state, afterSegment, afterLast, memory);
+                URI_FUNC(ParseZeroMoreSlashSegs)(state, afterSegment, afterLast, memory);
         if (afterZeroMoreSlashSegs == NULL) {
             return NULL;
         }
@@ -1633,7 +1634,7 @@ tail_call:
 
     case _UT(':'): {
         const URI_CHAR * const afterHierPart =
-            URI_FUNC(ParseHierPart)(state, first + 1, afterLast, memory);
+                URI_FUNC(ParseHierPart)(state, first + 1, afterLast, memory);
         state->uri->scheme.afterLast = first; /* SCHEME END */
         if (afterHierPart == NULL) {
             return NULL;
@@ -1688,7 +1689,7 @@ static const URI_CHAR * URI_FUNC(ParseUriReference)(URI_TYPE(ParserState) * stat
 
     case _UT('%'): {
         const URI_CHAR * const afterPctEncoded =
-            URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
+                URI_FUNC(ParsePctEncoded)(state, first, afterLast, memory);
         if (afterPctEncoded == NULL) {
             return NULL;
         }
@@ -1699,7 +1700,7 @@ static const URI_CHAR * URI_FUNC(ParseUriReference)(URI_TYPE(ParserState) * stat
 
     case _UT('/'): {
         const URI_CHAR * const afterPartHelperTwo =
-            URI_FUNC(ParsePartHelperTwo)(state, first + 1, afterLast, memory);
+                URI_FUNC(ParsePartHelperTwo)(state, first + 1, afterLast, memory);
         if (afterPartHelperTwo == NULL) {
             return NULL;
         }
@@ -1727,7 +1728,7 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseUriTail)(URI_TYPE(ParserState) 
     switch (*first) {
     case _UT('#'): {
         const URI_CHAR * const afterQueryFrag =
-            URI_FUNC(ParseQueryFrag)(state, first + 1, afterLast, memory);
+                URI_FUNC(ParseQueryFrag)(state, first + 1, afterLast, memory);
         if (afterQueryFrag == NULL) {
             return NULL;
         }
@@ -1738,7 +1739,7 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseUriTail)(URI_TYPE(ParserState) 
 
     case _UT('?'): {
         const URI_CHAR * const afterQueryFrag =
-            URI_FUNC(ParseQueryFrag)(state, first + 1, afterLast, memory);
+                URI_FUNC(ParseQueryFrag)(state, first + 1, afterLast, memory);
         if (afterQueryFrag == NULL) {
             return NULL;
         }
@@ -1766,7 +1767,7 @@ URI_FUNC(ParseUriTailTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
     switch (*first) {
     case _UT('#'): {
         const URI_CHAR * const afterQueryFrag =
-            URI_FUNC(ParseQueryFrag)(state, first + 1, afterLast, memory);
+                URI_FUNC(ParseQueryFrag)(state, first + 1, afterLast, memory);
         if (afterQueryFrag == NULL) {
             return NULL;
         }
@@ -1796,7 +1797,7 @@ tail_call:
     switch (*first) {
     case _UT('/'): {
         const URI_CHAR * const afterSegment =
-            URI_FUNC(ParseSegment)(state, first + 1, afterLast, memory);
+                URI_FUNC(ParseSegment)(state, first + 1, afterLast, memory);
         if (afterSegment == NULL) {
             return NULL;
         }
@@ -1826,7 +1827,7 @@ static URI_INLINE UriBool URI_FUNC(PushPathSegment)(URI_TYPE(ParserState) * stat
                                                     const URI_CHAR * afterLast,
                                                     UriMemoryManager * memory) {
     URI_TYPE(PathSegment) * segment =
-        memory->calloc(memory, 1, sizeof(URI_TYPE(PathSegment)));
+            memory->calloc(memory, 1, sizeof(URI_TYPE(PathSegment)));
     if (segment == NULL) {
         return URI_FALSE; /* Raises malloc error */
     }

--- a/src/UriParse.c
+++ b/src/UriParse.c
@@ -75,156 +75,96 @@
 #  endif
 
 static const URI_CHAR * URI_FUNC(ParseAuthority)(URI_TYPE(ParserState) * state,
-                                                 const URI_CHAR * first,
-                                                 const URI_CHAR * afterLast,
-                                                 UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseAuthorityTwo)(URI_TYPE(ParserState) * state,
-                                                    const URI_CHAR * first,
-                                                    const URI_CHAR * afterLast);
-static const URI_CHAR * URI_FUNC(ParseHexZero)(const URI_CHAR * first,
-                                               const URI_CHAR * afterLast);
+        const URI_CHAR * first, const URI_CHAR * afterLast);
+static const URI_CHAR * URI_FUNC(ParseHexZero)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
 static const URI_CHAR * URI_FUNC(ParseHierPart)(URI_TYPE(ParserState) * state,
-                                                const URI_CHAR * first,
-                                                const URI_CHAR * afterLast,
-                                                UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseIpFutLoop)(URI_TYPE(ParserState) * state,
-                                                 const URI_CHAR * first,
-                                                 const URI_CHAR * afterLast,
-                                                 UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseIpLit2)(URI_TYPE(ParserState) * state,
-                                              const URI_CHAR * first,
-                                              const URI_CHAR * afterLast,
-                                              UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * state,
-                                                    const URI_CHAR * first,
-                                                    const URI_CHAR * afterLast,
-                                                    UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseMustBeSegmentNzNc)(URI_TYPE(ParserState) * state,
-                                                         const URI_CHAR * first,
-                                                         const URI_CHAR * afterLast,
-                                                         UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseOwnHost)(URI_TYPE(ParserState) * state,
-                                               const URI_CHAR * first,
-                                               const URI_CHAR * afterLast,
-                                               UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseOwnHost2)(URI_TYPE(ParserState) * state,
-                                                const URI_CHAR * first,
-                                                const URI_CHAR * afterLast,
-                                                UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseOwnHostUserInfoNz)(URI_TYPE(ParserState) * state,
-                                                         const URI_CHAR * first,
-                                                         const URI_CHAR * afterLast,
-                                                         UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseOwnPortUserInfo)(URI_TYPE(ParserState) * state,
-                                                       const URI_CHAR * first,
-                                                       const URI_CHAR * afterLast,
-                                                       UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseOwnUserInfo)(URI_TYPE(ParserState) * state,
-                                                   const URI_CHAR * first,
-                                                   const URI_CHAR * afterLast,
-                                                   UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParsePartHelperTwo)(URI_TYPE(ParserState) * state,
-                                                     const URI_CHAR * first,
-                                                     const URI_CHAR * afterLast,
-                                                     UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParsePathAbsEmpty)(URI_TYPE(ParserState) * state,
-                                                    const URI_CHAR * first,
-                                                    const URI_CHAR * afterLast,
-                                                    UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParsePathAbsNoLeadSlash)(URI_TYPE(ParserState) * state,
-                                                          const URI_CHAR * first,
-                                                          const URI_CHAR * afterLast,
-                                                          UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParsePathRootless)(URI_TYPE(ParserState) * state,
-                                                    const URI_CHAR * first,
-                                                    const URI_CHAR * afterLast,
-                                                    UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParsePchar)(URI_TYPE(ParserState) * state,
-                                             const URI_CHAR * first,
-                                             const URI_CHAR * afterLast,
-                                             UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParsePctEncoded)(URI_TYPE(ParserState) * state,
-                                                  const URI_CHAR * first,
-                                                  const URI_CHAR * afterLast,
-                                                  UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParsePctSubUnres)(URI_TYPE(ParserState) * state,
-                                                   const URI_CHAR * first,
-                                                   const URI_CHAR * afterLast,
-                                                   UriMemoryManager * memory);
-static const URI_CHAR * URI_FUNC(ParsePort)(const URI_CHAR * first,
-                                            const URI_CHAR * afterLast);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
+static const URI_CHAR * URI_FUNC(ParsePort)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
 static const URI_CHAR * URI_FUNC(ParseQueryFrag)(URI_TYPE(ParserState) * state,
-                                                 const URI_CHAR * first,
-                                                 const URI_CHAR * afterLast,
-                                                 UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseSegment)(URI_TYPE(ParserState) * state,
-                                               const URI_CHAR * first,
-                                               const URI_CHAR * afterLast,
-                                               UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseSegmentNz)(URI_TYPE(ParserState) * state,
-                                                 const URI_CHAR * first,
-                                                 const URI_CHAR * afterLast,
-                                                 UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseSegmentNzNcOrScheme2)(URI_TYPE(ParserState) * state,
-                                                            const URI_CHAR * first,
-                                                            const URI_CHAR * afterLast,
-                                                            UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseUriReference)(URI_TYPE(ParserState) * state,
-                                                    const URI_CHAR * first,
-                                                    const URI_CHAR * afterLast,
-                                                    UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseUriTail)(URI_TYPE(ParserState) * state,
-                                               const URI_CHAR * first,
-                                               const URI_CHAR * afterLast,
-                                               UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseUriTailTwo)(URI_TYPE(ParserState) * state,
-                                                  const URI_CHAR * first,
-                                                  const URI_CHAR * afterLast,
-                                                  UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 static const URI_CHAR * URI_FUNC(ParseZeroMoreSlashSegs)(URI_TYPE(ParserState) * state,
-                                                         const URI_CHAR * first,
-                                                         const URI_CHAR * afterLast,
-                                                         UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 
-static UriBool URI_FUNC(OnExitOwnHost2)(URI_TYPE(ParserState) * state,
-                                        const URI_CHAR * first,
-                                        UriMemoryManager * memory);
-static UriBool URI_FUNC(OnExitOwnHostUserInfo)(URI_TYPE(ParserState) * state,
-                                               const URI_CHAR * first,
-                                               UriMemoryManager * memory);
-static UriBool URI_FUNC(OnExitOwnPortUserInfo)(URI_TYPE(ParserState) * state,
-                                               const URI_CHAR * first,
-                                               UriMemoryManager * memory);
-static UriBool URI_FUNC(OnExitSegmentNzNcOrScheme2)(URI_TYPE(ParserState) * state,
-                                                    const URI_CHAR * first,
-                                                    UriMemoryManager * memory);
+static UriBool URI_FUNC(OnExitOwnHost2)(
+        URI_TYPE(ParserState) * state, const URI_CHAR * first, UriMemoryManager * memory);
+static UriBool URI_FUNC(OnExitOwnHostUserInfo)(
+        URI_TYPE(ParserState) * state, const URI_CHAR * first, UriMemoryManager * memory);
+static UriBool URI_FUNC(OnExitOwnPortUserInfo)(
+        URI_TYPE(ParserState) * state, const URI_CHAR * first, UriMemoryManager * memory);
+static UriBool URI_FUNC(OnExitSegmentNzNcOrScheme2)(
+        URI_TYPE(ParserState) * state, const URI_CHAR * first, UriMemoryManager * memory);
 static void URI_FUNC(OnExitPartHelperTwo)(URI_TYPE(ParserState) * state);
 
 static void URI_FUNC(ResetParserStateExceptUri)(URI_TYPE(ParserState) * state);
 
 static UriBool URI_FUNC(PushPathSegment)(URI_TYPE(ParserState) * state,
-                                         const URI_CHAR * first,
-                                         const URI_CHAR * afterLast,
-                                         UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 static void URI_FUNC(StopSyntax)(URI_TYPE(ParserState) * state, const URI_CHAR * errorPos,
-                                 UriMemoryManager * memory);
-static void URI_FUNC(StopMalloc)(URI_TYPE(ParserState) * state,
-                                 UriMemoryManager * memory);
+        UriMemoryManager * memory);
+static void URI_FUNC(StopMalloc)(
+        URI_TYPE(ParserState) * state, UriMemoryManager * memory);
 
 static int URI_FUNC(ParseUriExMm)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
-                                  const URI_CHAR * afterLast, UriMemoryManager * memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 static URI_INLINE void URI_FUNC(StopSyntax)(URI_TYPE(ParserState) * state,
-                                            const URI_CHAR * errorPos,
-                                            UriMemoryManager * memory) {
+        const URI_CHAR * errorPos, UriMemoryManager * memory) {
     URI_FUNC(FreeUriMembersMm)(state->uri, memory);
     state->errorPos = errorPos;
     state->errorCode = URI_ERROR_SYNTAX;
 }
 
-static URI_INLINE void URI_FUNC(StopMalloc)(URI_TYPE(ParserState) * state,
-                                            UriMemoryManager * memory) {
+static URI_INLINE void URI_FUNC(StopMalloc)(
+        URI_TYPE(ParserState) * state, UriMemoryManager * memory) {
     URI_FUNC(FreeUriMembersMm)(state->uri, memory);
     state->errorPos = NULL;
     state->errorCode = URI_ERROR_MALLOC;
@@ -236,9 +176,7 @@ static URI_INLINE void URI_FUNC(StopMalloc)(URI_TYPE(ParserState) * state,
  * [authority]-><NULL>
  */
 static URI_INLINE const URI_CHAR * URI_FUNC(ParseAuthority)(URI_TYPE(ParserState) * state,
-                                                            const URI_CHAR * first,
-                                                            const URI_CHAR * afterLast,
-                                                            UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     if (first >= afterLast) {
         /* "" regname host */
         state->uri->hostText.first = URI_FUNC(SafeToPointTo);
@@ -273,9 +211,9 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseAuthority)(URI_TYPE(ParserState
  * [authorityTwo]-><:>[port]
  * [authorityTwo]-><NULL>
  */
-static URI_INLINE const URI_CHAR *
-URI_FUNC(ParseAuthorityTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
-                            const URI_CHAR * afterLast) {
+static URI_INLINE const URI_CHAR * URI_FUNC(ParseAuthorityTwo)(
+        URI_TYPE(ParserState) * state, const URI_CHAR * first,
+        const URI_CHAR * afterLast) {
     if (first >= afterLast) {
         return afterLast;
     }
@@ -300,8 +238,8 @@ URI_FUNC(ParseAuthorityTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * firs
  * [hexZero]->[HEXDIG][hexZero]
  * [hexZero]-><NULL>
  */
-static const URI_CHAR * URI_FUNC(ParseHexZero)(const URI_CHAR * first,
-                                               const URI_CHAR * afterLast) {
+static const URI_CHAR * URI_FUNC(ParseHexZero)(
+        const URI_CHAR * first, const URI_CHAR * afterLast) {
 tail_call:
     if (first >= afterLast) {
         return afterLast;
@@ -323,9 +261,7 @@ tail_call:
  * [hierPart]-><NULL>
  */
 static URI_INLINE const URI_CHAR * URI_FUNC(ParseHierPart)(URI_TYPE(ParserState) * state,
-                                                           const URI_CHAR * first,
-                                                           const URI_CHAR * afterLast,
-                                                           UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     if (first >= afterLast) {
         return afterLast;
     }
@@ -351,9 +287,7 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseHierPart)(URI_TYPE(ParserState)
  * [ipFutStopGo]-><NULL>
  */
 static const URI_CHAR * URI_FUNC(ParseIpFutLoop)(URI_TYPE(ParserState) * state,
-                                                 const URI_CHAR * first,
-                                                 const URI_CHAR * afterLast,
-                                                 UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     const URI_CHAR * const originalFirst = first;
 
     while (first < afterLast) {
@@ -383,9 +317,7 @@ done_looping:
  * [ipFuture]-><v>[HEXDIG][hexZero]<.>[ipFutLoop]
  */
 static const URI_CHAR * URI_FUNC(ParseIpFuture)(URI_TYPE(ParserState) * state,
-                                                const URI_CHAR * first,
-                                                const URI_CHAR * afterLast,
-                                                UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     if (first >= afterLast) {
         URI_FUNC(StopSyntax)(state, afterLast, memory);
         return NULL;
@@ -450,9 +382,7 @@ static const URI_CHAR * URI_FUNC(ParseIpFuture)(URI_TYPE(ParserState) * state,
  * [ipLit2]->[IPv6address2]
  */
 static URI_INLINE const URI_CHAR * URI_FUNC(ParseIpLit2)(URI_TYPE(ParserState) * state,
-                                                         const URI_CHAR * first,
-                                                         const URI_CHAR * afterLast,
-                                                         UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     if (first >= afterLast) {
         URI_FUNC(StopSyntax)(state, afterLast, memory);
         return NULL;
@@ -499,9 +429,7 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseIpLit2)(URI_TYPE(ParserState) *
  * [IPv6address2]->..<]>
  */
 static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * state,
-                                                    const URI_CHAR * first,
-                                                    const URI_CHAR * afterLast,
-                                                    UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     int zipperEver = 0;
     int quadsDone = 0;
     int digitCount = 0;
@@ -532,7 +460,7 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
 
                 case _UT('.'):
                     if ((ip4OctetsDone == 4) /* NOTE! */
-                        || (digitCount == 0) || (digitCount == 4)) {
+                            || (digitCount == 0) || (digitCount == 4)) {
                         /* Invalid digit or octet count */
                         URI_FUNC(StopSyntax)(state, first, memory);
                         return NULL;
@@ -542,8 +470,8 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
                         return NULL;
                     } else if ((digitCount == 3)
                                && (100 * digitHistory[0] + 10 * digitHistory[1]
-                                           + digitHistory[2]
-                                   > 255)) {
+                                               + digitHistory[2]
+                                       > 255)) {
                         /* Octet value too large */
                         if (digitHistory[0] > 2) {
                             URI_FUNC(StopSyntax)(state, first - 3, memory);
@@ -564,7 +492,7 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
 
                 case _UT(']'):
                     if ((ip4OctetsDone != 3) /* NOTE! */
-                        || (digitCount == 0) || (digitCount == 4)) {
+                            || (digitCount == 0) || (digitCount == 4)) {
                         /* Invalid digit or octet count */
                         URI_FUNC(StopSyntax)(state, first, memory);
                         return NULL;
@@ -574,8 +502,8 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
                         return NULL;
                     } else if ((digitCount == 3)
                                && (100 * digitHistory[0] + 10 * digitHistory[1]
-                                           + digitHistory[2]
-                                   > 255)) {
+                                               + digitHistory[2]
+                                       > 255)) {
                         /* Octet value too large */
                         if (digitHistory[0] > 2) {
                             URI_FUNC(StopSyntax)(state, first - 3, memory);
@@ -591,8 +519,8 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
 
                     /* Copy missing quads right before IPv4 */
                     memcpy(state->uri->hostData.ip6->data + 16 - 4
-                                   - 2 * quadsAfterZipperCount,
-                           quadsAfterZipper, 2 * quadsAfterZipperCount);
+                                    - 2 * quadsAfterZipperCount,
+                            quadsAfterZipper, 2 * quadsAfterZipperCount);
 
                     /* Copy last IPv4 octet */
                     state->uri->hostData.ip6->data[16 - 4 + 3] =
@@ -652,13 +580,11 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
                     if (digitCount > 0) {
                         if (zipperEver) {
                             uriWriteQuadToDoubleByte(digitHistory, digitCount,
-                                                     quadsAfterZipper
-                                                             + 2 * quadsAfterZipperCount);
+                                    quadsAfterZipper + 2 * quadsAfterZipperCount);
                             quadsAfterZipperCount++;
                         } else {
                             uriWriteQuadToDoubleByte(digitHistory, digitCount,
-                                                     state->uri->hostData.ip6->data
-                                                             + 2 * quadsDone);
+                                    state->uri->hostData.ip6->data + 2 * quadsDone);
                         }
                         quadsDone++;
                         digitCount = 0;
@@ -687,7 +613,7 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
 
                         /* Zero everything after zipper */
                         memset(state->uri->hostData.ip6->data + resetOffset, 0,
-                               16 - resetOffset);
+                                16 - resetOffset);
                         setZipper = 1;
 
                         /* ":::+"? */
@@ -712,8 +638,8 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
 
                 case _UT('.'):
                     if ((quadsDone + zipperEver > 6) /* NOTE */
-                        || (!zipperEver && (quadsDone < 6)) || letterAmong
-                        || (digitCount == 0) || (digitCount == 4)) {
+                            || (!zipperEver && (quadsDone < 6)) || letterAmong
+                            || (digitCount == 0) || (digitCount == 4)) {
                         /* Invalid octet before */
                         URI_FUNC(StopSyntax)(state, first, memory);
                         return NULL;
@@ -723,8 +649,8 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
                         return NULL;
                     } else if ((digitCount == 3)
                                && (100 * digitHistory[0] + 10 * digitHistory[1]
-                                           + digitHistory[2]
-                                   > 255)) {
+                                               + digitHistory[2]
+                                       > 255)) {
                         /* Octet value too large */
                         if (digitHistory[0] > 2) {
                             URI_FUNC(StopSyntax)(state, first - 3, memory);
@@ -761,13 +687,11 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
                                 return NULL;
                             }
                             uriWriteQuadToDoubleByte(digitHistory, digitCount,
-                                                     quadsAfterZipper
-                                                             + 2 * quadsAfterZipperCount);
+                                    quadsAfterZipper + 2 * quadsAfterZipperCount);
                             quadsAfterZipperCount++;
                         } else {
                             uriWriteQuadToDoubleByte(digitHistory, digitCount,
-                                                     state->uri->hostData.ip6->data
-                                                             + 2 * quadsDone);
+                                    state->uri->hostData.ip6->data + 2 * quadsDone);
                         }
                         /*
                         quadsDone++;
@@ -777,8 +701,8 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
 
                     /* Copy missing quads to the end */
                     memcpy(state->uri->hostData.ip6->data + 16
-                                   - 2 * quadsAfterZipperCount,
-                           quadsAfterZipper, 2 * quadsAfterZipperCount);
+                                    - 2 * quadsAfterZipperCount,
+                            quadsAfterZipper, 2 * quadsAfterZipperCount);
 
                     state->uri->hostText.afterLast = first; /* HOST END */
                     return first + 1; /* Fine */
@@ -807,13 +731,11 @@ static const URI_CHAR * URI_FUNC(ParseIPv6address2)(URI_TYPE(ParserState) * stat
  * [mustBeSegmentNzNc]-><@>[mustBeSegmentNzNc]
  */
 static const URI_CHAR * URI_FUNC(ParseMustBeSegmentNzNc)(URI_TYPE(ParserState) * state,
-                                                         const URI_CHAR * first,
-                                                         const URI_CHAR * afterLast,
-                                                         UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
 tail_call:
     if (first >= afterLast) {
-        if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first,
-                                       memory)) { /* SEGMENT BOTH */
+        if (!URI_FUNC(PushPathSegment)(
+                    state, state->uri->scheme.first, first, memory)) { /* SEGMENT BOTH */
             URI_FUNC(StopMalloc)(state, memory);
             return NULL;
         }
@@ -841,8 +763,8 @@ tail_call:
     case _UT('/'): {
         const URI_CHAR * afterZeroMoreSlashSegs;
         const URI_CHAR * afterSegment;
-        if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first,
-                                       memory)) { /* SEGMENT BOTH */
+        if (!URI_FUNC(PushPathSegment)(
+                    state, state->uri->scheme.first, first, memory)) { /* SEGMENT BOTH */
             URI_FUNC(StopMalloc)(state, memory);
             return NULL;
         }
@@ -851,8 +773,8 @@ tail_call:
         if (afterSegment == NULL) {
             return NULL;
         }
-        if (!URI_FUNC(PushPathSegment)(state, first + 1, afterSegment,
-                                       memory)) { /* SEGMENT BOTH */
+        if (!URI_FUNC(PushPathSegment)(
+                    state, first + 1, afterSegment, memory)) { /* SEGMENT BOTH */
             URI_FUNC(StopMalloc)(state, memory);
             return NULL;
         }
@@ -865,8 +787,8 @@ tail_call:
     }
 
     default:
-        if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first,
-                                       memory)) { /* SEGMENT BOTH */
+        if (!URI_FUNC(PushPathSegment)(
+                    state, state->uri->scheme.first, first, memory)) { /* SEGMENT BOTH */
             URI_FUNC(StopMalloc)(state, memory);
             return NULL;
         }
@@ -880,9 +802,7 @@ tail_call:
  * [ownHost]->[ownHost2] // can take <NULL>
  */
 static URI_INLINE const URI_CHAR * URI_FUNC(ParseOwnHost)(URI_TYPE(ParserState) * state,
-                                                          const URI_CHAR * first,
-                                                          const URI_CHAR * afterLast,
-                                                          UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     if (first >= afterLast) {
         state->uri->hostText.afterLast = afterLast; /* HOST END */
         return afterLast;
@@ -905,8 +825,7 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseOwnHost)(URI_TYPE(ParserState) 
 }
 
 static URI_INLINE UriBool URI_FUNC(OnExitOwnHost2)(URI_TYPE(ParserState) * state,
-                                                   const URI_CHAR * first,
-                                                   UriMemoryManager * memory) {
+        const URI_CHAR * first, UriMemoryManager * memory) {
     state->uri->hostText.afterLast = first; /* HOST END */
 
     /* Valid IPv4 or just a regname? */
@@ -916,8 +835,7 @@ static URI_INLINE UriBool URI_FUNC(OnExitOwnHost2)(URI_TYPE(ParserState) * state
         return URI_FALSE; /* Raises malloc error */
     }
     if (URI_FUNC(ParseIpFourAddress)(state->uri->hostData.ip4->data,
-                                     state->uri->hostText.first,
-                                     state->uri->hostText.afterLast)) {
+                state->uri->hostText.first, state->uri->hostText.afterLast)) {
         /* Not IPv4 */
         memory->free(memory, state->uri->hostData.ip4);
         state->uri->hostData.ip4 = NULL;
@@ -930,9 +848,7 @@ static URI_INLINE UriBool URI_FUNC(OnExitOwnHost2)(URI_TYPE(ParserState) * state
  * [ownHost2]->[pctSubUnres][ownHost2]
  */
 static const URI_CHAR * URI_FUNC(ParseOwnHost2)(URI_TYPE(ParserState) * state,
-                                                const URI_CHAR * first,
-                                                const URI_CHAR * afterLast,
-                                                UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
 tail_call:
     if (first >= afterLast) {
         if (!URI_FUNC(OnExitOwnHost2)(state, first, memory)) {
@@ -965,8 +881,7 @@ tail_call:
 }
 
 static URI_INLINE UriBool URI_FUNC(OnExitOwnHostUserInfo)(URI_TYPE(ParserState) * state,
-                                                          const URI_CHAR * first,
-                                                          UriMemoryManager * memory) {
+        const URI_CHAR * first, UriMemoryManager * memory) {
     state->uri->hostText.first =
             state->uri->userInfo.first; /* Host instead of userInfo, update */
     state->uri->userInfo.first = NULL; /* Not a userInfo, reset */
@@ -979,8 +894,7 @@ static URI_INLINE UriBool URI_FUNC(OnExitOwnHostUserInfo)(URI_TYPE(ParserState) 
         return URI_FALSE; /* Raises malloc error */
     }
     if (URI_FUNC(ParseIpFourAddress)(state->uri->hostData.ip4->data,
-                                     state->uri->hostText.first,
-                                     state->uri->hostText.afterLast)) {
+                state->uri->hostText.first, state->uri->hostText.afterLast)) {
         /* Not IPv4 */
         memory->free(memory, state->uri->hostData.ip4);
         state->uri->hostData.ip4 = NULL;
@@ -997,9 +911,7 @@ static URI_INLINE UriBool URI_FUNC(OnExitOwnHostUserInfo)(URI_TYPE(ParserState) 
  * [ownHostUserInfo]-><NULL>
  */
 static const URI_CHAR * URI_FUNC(ParseOwnHostUserInfoNz)(URI_TYPE(ParserState) * state,
-                                                         const URI_CHAR * first,
-                                                         const URI_CHAR * afterLast,
-                                                         UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     const URI_CHAR * const originalFirst = first;
 
     while (first < afterLast) {
@@ -1054,8 +966,7 @@ done_looping:
 }
 
 static URI_INLINE UriBool URI_FUNC(OnExitOwnPortUserInfo)(URI_TYPE(ParserState) * state,
-                                                          const URI_CHAR * first,
-                                                          UriMemoryManager * memory) {
+        const URI_CHAR * first, UriMemoryManager * memory) {
     state->uri->hostText.first =
             state->uri->userInfo.first; /* Host instead of userInfo, update */
     state->uri->userInfo.first = NULL; /* Not a userInfo, reset */
@@ -1068,8 +979,7 @@ static URI_INLINE UriBool URI_FUNC(OnExitOwnPortUserInfo)(URI_TYPE(ParserState) 
         return URI_FALSE; /* Raises malloc error */
     }
     if (URI_FUNC(ParseIpFourAddress)(state->uri->hostData.ip4->data,
-                                     state->uri->hostText.first,
-                                     state->uri->hostText.afterLast)) {
+                state->uri->hostText.first, state->uri->hostText.afterLast)) {
         /* Not IPv4 */
         memory->free(memory, state->uri->hostData.ip4);
         state->uri->hostData.ip4 = NULL;
@@ -1091,9 +1001,7 @@ static URI_INLINE UriBool URI_FUNC(OnExitOwnPortUserInfo)(URI_TYPE(ParserState) 
  * [ownPortUserInfo]-><NULL>
  */
 static const URI_CHAR * URI_FUNC(ParseOwnPortUserInfo)(URI_TYPE(ParserState) * state,
-                                                       const URI_CHAR * first,
-                                                       const URI_CHAR * afterLast,
-                                                       UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
 tail_call:
     if (first >= afterLast) {
         if (!URI_FUNC(OnExitOwnPortUserInfo)(state, first, memory)) {
@@ -1152,9 +1060,7 @@ tail_call:
  * [ownUserInfo]-><@>[ownHost]
  */
 static const URI_CHAR * URI_FUNC(ParseOwnUserInfo)(URI_TYPE(ParserState) * state,
-                                                   const URI_CHAR * first,
-                                                   const URI_CHAR * afterLast,
-                                                   UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
 tail_call:
     if (first >= afterLast) {
         URI_FUNC(StopSyntax)(state, afterLast, memory);
@@ -1198,9 +1104,9 @@ static URI_INLINE void URI_FUNC(OnExitPartHelperTwo)(URI_TYPE(ParserState) * sta
  * [partHelperTwo]->[pathAbsNoLeadSlash] // can take <NULL>
  * [partHelperTwo]-></>[authority][pathAbsEmpty]
  */
-static URI_INLINE const URI_CHAR *
-URI_FUNC(ParsePartHelperTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
-                             const URI_CHAR * afterLast, UriMemoryManager * memory) {
+static URI_INLINE const URI_CHAR * URI_FUNC(ParsePartHelperTwo)(
+        URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast,
+        UriMemoryManager * memory) {
     if (first >= afterLast) {
         URI_FUNC(OnExitPartHelperTwo)(state);
         return afterLast;
@@ -1233,9 +1139,7 @@ URI_FUNC(ParsePartHelperTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * fir
  * [pathAbsEmpty]-><NULL>
  */
 static const URI_CHAR * URI_FUNC(ParsePathAbsEmpty)(URI_TYPE(ParserState) * state,
-                                                    const URI_CHAR * first,
-                                                    const URI_CHAR * afterLast,
-                                                    UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
 tail_call:
     if (first >= afterLast) {
         return afterLast;
@@ -1248,8 +1152,8 @@ tail_call:
         if (afterSegment == NULL) {
             return NULL;
         }
-        if (!URI_FUNC(PushPathSegment)(state, first + 1, afterSegment,
-                                       memory)) { /* SEGMENT BOTH */
+        if (!URI_FUNC(PushPathSegment)(
+                    state, first + 1, afterSegment, memory)) { /* SEGMENT BOTH */
             URI_FUNC(StopMalloc)(state, memory);
             return NULL;
         }
@@ -1266,9 +1170,9 @@ tail_call:
  * [pathAbsNoLeadSlash]->[segmentNz][zeroMoreSlashSegs]
  * [pathAbsNoLeadSlash]-><NULL>
  */
-static URI_INLINE const URI_CHAR *
-URI_FUNC(ParsePathAbsNoLeadSlash)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
-                                  const URI_CHAR * afterLast, UriMemoryManager * memory) {
+static URI_INLINE const URI_CHAR * URI_FUNC(ParsePathAbsNoLeadSlash)(
+        URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast,
+        UriMemoryManager * memory) {
     if (first >= afterLast) {
         return afterLast;
     }
@@ -1280,8 +1184,8 @@ URI_FUNC(ParsePathAbsNoLeadSlash)(URI_TYPE(ParserState) * state, const URI_CHAR 
         if (afterSegmentNz == NULL) {
             return NULL;
         }
-        if (!URI_FUNC(PushPathSegment)(state, first, afterSegmentNz,
-                                       memory)) { /* SEGMENT BOTH */
+        if (!URI_FUNC(PushPathSegment)(
+                    state, first, afterSegmentNz, memory)) { /* SEGMENT BOTH */
             URI_FUNC(StopMalloc)(state, memory);
             return NULL;
         }
@@ -1296,16 +1200,16 @@ URI_FUNC(ParsePathAbsNoLeadSlash)(URI_TYPE(ParserState) * state, const URI_CHAR 
 /*
  * [pathRootless]->[segmentNz][zeroMoreSlashSegs]
  */
-static URI_INLINE const URI_CHAR *
-URI_FUNC(ParsePathRootless)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
-                            const URI_CHAR * afterLast, UriMemoryManager * memory) {
+static URI_INLINE const URI_CHAR * URI_FUNC(ParsePathRootless)(
+        URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast,
+        UriMemoryManager * memory) {
     const URI_CHAR * const afterSegmentNz =
             URI_FUNC(ParseSegmentNz)(state, first, afterLast, memory);
     if (afterSegmentNz == NULL) {
         return NULL;
     } else {
-        if (!URI_FUNC(PushPathSegment)(state, first, afterSegmentNz,
-                                       memory)) { /* SEGMENT BOTH */
+        if (!URI_FUNC(PushPathSegment)(
+                    state, first, afterSegmentNz, memory)) { /* SEGMENT BOTH */
             URI_FUNC(StopMalloc)(state, memory);
             return NULL;
         }
@@ -1321,9 +1225,7 @@ URI_FUNC(ParsePathRootless)(URI_TYPE(ParserState) * state, const URI_CHAR * firs
  * [pchar]-><@>
  */
 static const URI_CHAR * URI_FUNC(ParsePchar)(URI_TYPE(ParserState) * state,
-                                             const URI_CHAR * first,
-                                             const URI_CHAR * afterLast,
-                                             UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     if (first >= afterLast) {
         URI_FUNC(StopSyntax)(state, afterLast, memory);
         return NULL;
@@ -1346,9 +1248,7 @@ static const URI_CHAR * URI_FUNC(ParsePchar)(URI_TYPE(ParserState) * state,
  * [pctEncoded]-><%>[HEXDIG][HEXDIG]
  */
 static const URI_CHAR * URI_FUNC(ParsePctEncoded)(URI_TYPE(ParserState) * state,
-                                                  const URI_CHAR * first,
-                                                  const URI_CHAR * afterLast,
-                                                  UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     if (first >= afterLast) {
         URI_FUNC(StopSyntax)(state, afterLast, memory);
         return NULL;
@@ -1401,9 +1301,7 @@ static const URI_CHAR * URI_FUNC(ParsePctEncoded)(URI_TYPE(ParserState) * state,
  * [pctSubUnres]->[unreserved]
  */
 static const URI_CHAR * URI_FUNC(ParsePctSubUnres)(URI_TYPE(ParserState) * state,
-                                                   const URI_CHAR * first,
-                                                   const URI_CHAR * afterLast,
-                                                   UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     if (first >= afterLast) {
         URI_FUNC(StopSyntax)(state, afterLast, memory);
         return NULL;
@@ -1427,8 +1325,8 @@ static const URI_CHAR * URI_FUNC(ParsePctSubUnres)(URI_TYPE(ParserState) * state
  * [port]->[DIGIT][port]
  * [port]-><NULL>
  */
-static const URI_CHAR * URI_FUNC(ParsePort)(const URI_CHAR * first,
-                                            const URI_CHAR * afterLast) {
+static const URI_CHAR * URI_FUNC(ParsePort)(
+        const URI_CHAR * first, const URI_CHAR * afterLast) {
 tail_call:
     if (first >= afterLast) {
         return afterLast;
@@ -1451,9 +1349,7 @@ tail_call:
  * [queryFrag]-><NULL>
  */
 static const URI_CHAR * URI_FUNC(ParseQueryFrag)(URI_TYPE(ParserState) * state,
-                                                 const URI_CHAR * first,
-                                                 const URI_CHAR * afterLast,
-                                                 UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
 tail_call:
     if (first >= afterLast) {
         return afterLast;
@@ -1485,9 +1381,7 @@ tail_call:
  * [segment]-><NULL>
  */
 static const URI_CHAR * URI_FUNC(ParseSegment)(URI_TYPE(ParserState) * state,
-                                               const URI_CHAR * first,
-                                               const URI_CHAR * afterLast,
-                                               UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
 tail_call:
     if (first >= afterLast) {
         return afterLast;
@@ -1513,9 +1407,7 @@ tail_call:
  * [segmentNz]->[pchar][segment]
  */
 static URI_INLINE const URI_CHAR * URI_FUNC(ParseSegmentNz)(URI_TYPE(ParserState) * state,
-                                                            const URI_CHAR * first,
-                                                            const URI_CHAR * afterLast,
-                                                            UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     const URI_CHAR * const afterPchar =
             URI_FUNC(ParsePchar)(state, first, afterLast, memory);
     if (afterPchar == NULL) {
@@ -1524,11 +1416,11 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseSegmentNz)(URI_TYPE(ParserState
     return URI_FUNC(ParseSegment)(state, afterPchar, afterLast, memory);
 }
 
-static URI_INLINE UriBool
-URI_FUNC(OnExitSegmentNzNcOrScheme2)(URI_TYPE(ParserState) * state,
-                                     const URI_CHAR * first, UriMemoryManager * memory) {
-    if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first,
-                                   memory)) { /* SEGMENT BOTH */
+static URI_INLINE UriBool URI_FUNC(OnExitSegmentNzNcOrScheme2)(
+        URI_TYPE(ParserState) * state, const URI_CHAR * first,
+        UriMemoryManager * memory) {
+    if (!URI_FUNC(PushPathSegment)(
+                state, state->uri->scheme.first, first, memory)) { /* SEGMENT BOTH */
         return URI_FALSE; /* Raises malloc error*/
     }
     state->uri->scheme.first = NULL; /* Not a scheme, reset */
@@ -1560,9 +1452,7 @@ URI_FUNC(OnExitSegmentNzNcOrScheme2)(URI_TYPE(ParserState) * state,
  * [segmentNzNcOrScheme2]-><->[segmentNzNcOrScheme2]
  */
 static const URI_CHAR * URI_FUNC(ParseSegmentNzNcOrScheme2)(URI_TYPE(ParserState) * state,
-                                                            const URI_CHAR * first,
-                                                            const URI_CHAR * afterLast,
-                                                            UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
 tail_call:
     if (first >= afterLast) {
         if (!URI_FUNC(OnExitSegmentNzNcOrScheme2)(state, first, memory)) {
@@ -1587,8 +1477,8 @@ tail_call:
         if (afterPctEncoded == NULL) {
             return NULL;
         }
-        return URI_FUNC(ParseMustBeSegmentNzNc)(state, afterPctEncoded, afterLast,
-                                                memory);
+        return URI_FUNC(ParseMustBeSegmentNzNc)(
+                state, afterPctEncoded, afterLast, memory);
     }
 
     case _UT('!'):
@@ -1613,14 +1503,14 @@ tail_call:
         if (afterSegment == NULL) {
             return NULL;
         }
-        if (!URI_FUNC(PushPathSegment)(state, state->uri->scheme.first, first,
-                                       memory)) { /* SEGMENT BOTH */
+        if (!URI_FUNC(PushPathSegment)(
+                    state, state->uri->scheme.first, first, memory)) { /* SEGMENT BOTH */
             URI_FUNC(StopMalloc)(state, memory);
             return NULL;
         }
         state->uri->scheme.first = NULL; /* Not a scheme, reset */
-        if (!URI_FUNC(PushPathSegment)(state, first + 1, afterSegment,
-                                       memory)) { /* SEGMENT BOTH */
+        if (!URI_FUNC(PushPathSegment)(
+                    state, first + 1, afterSegment, memory)) { /* SEGMENT BOTH */
             URI_FUNC(StopMalloc)(state, memory);
             return NULL;
         }
@@ -1665,9 +1555,7 @@ tail_call:
  * [uriReference]-><->[mustBeSegmentNzNc]
  */
 static const URI_CHAR * URI_FUNC(ParseUriReference)(URI_TYPE(ParserState) * state,
-                                                    const URI_CHAR * first,
-                                                    const URI_CHAR * afterLast,
-                                                    UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     if (first >= afterLast) {
         return afterLast;
     }
@@ -1694,8 +1582,8 @@ static const URI_CHAR * URI_FUNC(ParseUriReference)(URI_TYPE(ParserState) * stat
             return NULL;
         }
         state->uri->scheme.first = first; /* SEGMENT BEGIN, ABUSE SCHEME POINTER */
-        return URI_FUNC(ParseMustBeSegmentNzNc)(state, afterPctEncoded, afterLast,
-                                                memory);
+        return URI_FUNC(ParseMustBeSegmentNzNc)(
+                state, afterPctEncoded, afterLast, memory);
     }
 
     case _UT('/'): {
@@ -1718,9 +1606,7 @@ static const URI_CHAR * URI_FUNC(ParseUriReference)(URI_TYPE(ParserState) * stat
  * [uriTail]-><NULL>
  */
 static URI_INLINE const URI_CHAR * URI_FUNC(ParseUriTail)(URI_TYPE(ParserState) * state,
-                                                          const URI_CHAR * first,
-                                                          const URI_CHAR * afterLast,
-                                                          UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     if (first >= afterLast) {
         return afterLast;
     }
@@ -1757,9 +1643,9 @@ static URI_INLINE const URI_CHAR * URI_FUNC(ParseUriTail)(URI_TYPE(ParserState) 
  * [uriTailTwo]-><#>[queryFrag]
  * [uriTailTwo]-><NULL>
  */
-static URI_INLINE const URI_CHAR *
-URI_FUNC(ParseUriTailTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
-                          const URI_CHAR * afterLast, UriMemoryManager * memory) {
+static URI_INLINE const URI_CHAR * URI_FUNC(ParseUriTailTwo)(
+        URI_TYPE(ParserState) * state, const URI_CHAR * first, const URI_CHAR * afterLast,
+        UriMemoryManager * memory) {
     if (first >= afterLast) {
         return afterLast;
     }
@@ -1786,9 +1672,7 @@ URI_FUNC(ParseUriTailTwo)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
  * [zeroMoreSlashSegs]-><NULL>
  */
 static const URI_CHAR * URI_FUNC(ParseZeroMoreSlashSegs)(URI_TYPE(ParserState) * state,
-                                                         const URI_CHAR * first,
-                                                         const URI_CHAR * afterLast,
-                                                         UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
 tail_call:
     if (first >= afterLast) {
         return afterLast;
@@ -1801,8 +1685,8 @@ tail_call:
         if (afterSegment == NULL) {
             return NULL;
         }
-        if (!URI_FUNC(PushPathSegment)(state, first + 1, afterSegment,
-                                       memory)) { /* SEGMENT BOTH */
+        if (!URI_FUNC(PushPathSegment)(
+                    state, first + 1, afterSegment, memory)) { /* SEGMENT BOTH */
             URI_FUNC(StopMalloc)(state, memory);
             return NULL;
         }
@@ -1815,17 +1699,15 @@ tail_call:
     }
 }
 
-static URI_INLINE void URI_FUNC(ResetParserStateExceptUri)(URI_TYPE(ParserState)
-                                                           * state) {
+static URI_INLINE void URI_FUNC(ResetParserStateExceptUri)(
+        URI_TYPE(ParserState) * state) {
     URI_TYPE(Uri) * const uriBackup = state->uri;
     memset(state, 0, sizeof(URI_TYPE(ParserState)));
     state->uri = uriBackup;
 }
 
 static URI_INLINE UriBool URI_FUNC(PushPathSegment)(URI_TYPE(ParserState) * state,
-                                                    const URI_CHAR * first,
-                                                    const URI_CHAR * afterLast,
-                                                    UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     URI_TYPE(PathSegment) * segment =
             memory->calloc(memory, 1, sizeof(URI_TYPE(PathSegment)));
     if (segment == NULL) {
@@ -1854,12 +1736,12 @@ static URI_INLINE UriBool URI_FUNC(PushPathSegment)(URI_TYPE(ParserState) * stat
 }
 
 int URI_FUNC(ParseUriEx)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
-                         const URI_CHAR * afterLast) {
+        const URI_CHAR * afterLast) {
     return URI_FUNC(ParseUriExMm)(state, first, afterLast, NULL);
 }
 
 static int URI_FUNC(ParseUriExMm)(URI_TYPE(ParserState) * state, const URI_CHAR * first,
-                                  const URI_CHAR * afterLast, UriMemoryManager * memory) {
+        const URI_CHAR * afterLast, UriMemoryManager * memory) {
     const URI_CHAR * afterUriReference;
     URI_TYPE(Uri) * uri;
 
@@ -1902,13 +1784,13 @@ int URI_FUNC(ParseUri)(URI_TYPE(ParserState) * state, const URI_CHAR * text) {
     return URI_FUNC(ParseUriEx)(state, text, text + URI_STRLEN(text));
 }
 
-int URI_FUNC(ParseSingleUri)(URI_TYPE(Uri) * uri, const URI_CHAR * text,
-                             const URI_CHAR ** errorPos) {
+int URI_FUNC(ParseSingleUri)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * text, const URI_CHAR ** errorPos) {
     return URI_FUNC(ParseSingleUriEx)(uri, text, NULL, errorPos);
 }
 
 int URI_FUNC(ParseSingleUriEx)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                               const URI_CHAR * afterLast, const URI_CHAR ** errorPos) {
+        const URI_CHAR * afterLast, const URI_CHAR ** errorPos) {
     if ((afterLast == NULL) && (first != NULL)) {
         afterLast = first + URI_STRLEN(first);
     }
@@ -1916,8 +1798,8 @@ int URI_FUNC(ParseSingleUriEx)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
 }
 
 int URI_FUNC(ParseSingleUriExMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                 const URI_CHAR * afterLast, const URI_CHAR ** errorPos,
-                                 UriMemoryManager * memory) {
+        const URI_CHAR * afterLast, const URI_CHAR ** errorPos,
+        UriMemoryManager * memory) {
     URI_TYPE(ParserState) state;
     int res;
 

--- a/src/UriParseBase.c
+++ b/src/UriParseBase.c
@@ -41,8 +41,8 @@
 #  include "UriParseBase.h"
 #endif
 
-void uriWriteQuadToDoubleByte(const unsigned char * hexDigits, int digitCount,
-                              unsigned char * output) {
+void uriWriteQuadToDoubleByte(
+        const unsigned char * hexDigits, int digitCount, unsigned char * output) {
     switch (digitCount) {
     case 1:
         /* 0x___? -> \x00 \x0? */

--- a/src/UriParseBase.h
+++ b/src/UriParseBase.h
@@ -42,8 +42,8 @@
 
 #  include <uriparser/UriBase.h>
 
-void uriWriteQuadToDoubleByte(const unsigned char * hexDigits, int digitCount,
-                              unsigned char * output);
+void uriWriteQuadToDoubleByte(
+        const unsigned char * hexDigits, int digitCount, unsigned char * output);
 unsigned char uriGetOctetValue(const unsigned char * digits, int digitCount);
 
 #endif /* URI_PARSE_BASE_H */

--- a/src/UriQuery.c
+++ b/src/UriQuery.c
@@ -70,51 +70,44 @@
 #  include <stdint.h>  // SIZE_MAX
 
 static int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest,
-                                        const URI_TYPE(QueryList) * queryList,
-                                        int maxChars, int * charsWritten,
-                                        int * charsRequired, UriBool spaceToPlus,
-                                        UriBool normalizeBreaks);
+        const URI_TYPE(QueryList) * queryList, int maxChars, int * charsWritten,
+        int * charsRequired, UriBool spaceToPlus, UriBool normalizeBreaks);
 
 static UriBool URI_FUNC(AppendQueryItem)(URI_TYPE(QueryList) * *prevNext, int * itemCount,
-                                         const URI_CHAR * keyFirst,
-                                         const URI_CHAR * keyAfter,
-                                         const URI_CHAR * valueFirst,
-                                         const URI_CHAR * valueAfter, UriBool plusToSpace,
-                                         UriBreakConversion breakConversion,
-                                         UriMemoryManager * memory);
+        const URI_CHAR * keyFirst, const URI_CHAR * keyAfter, const URI_CHAR * valueFirst,
+        const URI_CHAR * valueAfter, UriBool plusToSpace,
+        UriBreakConversion breakConversion, UriMemoryManager * memory);
 
-int URI_FUNC(ComposeQueryCharsRequired)(const URI_TYPE(QueryList) * queryList,
-                                        int * charsRequired) {
+int URI_FUNC(ComposeQueryCharsRequired)(
+        const URI_TYPE(QueryList) * queryList, int * charsRequired) {
     const UriBool spaceToPlus = URI_TRUE;
     const UriBool normalizeBreaks = URI_TRUE;
 
-    return URI_FUNC(ComposeQueryCharsRequiredEx)(queryList, charsRequired, spaceToPlus,
-                                                 normalizeBreaks);
+    return URI_FUNC(ComposeQueryCharsRequiredEx)(
+            queryList, charsRequired, spaceToPlus, normalizeBreaks);
 }
 
 int URI_FUNC(ComposeQueryCharsRequiredEx)(const URI_TYPE(QueryList) * queryList,
-                                          int * charsRequired, UriBool spaceToPlus,
-                                          UriBool normalizeBreaks) {
+        int * charsRequired, UriBool spaceToPlus, UriBool normalizeBreaks) {
     if ((queryList == NULL) || (charsRequired == NULL)) {
         return URI_ERROR_NULL;
     }
 
-    return URI_FUNC(ComposeQueryEngine)(NULL, queryList, 0, NULL, charsRequired,
-                                        spaceToPlus, normalizeBreaks);
+    return URI_FUNC(ComposeQueryEngine)(
+            NULL, queryList, 0, NULL, charsRequired, spaceToPlus, normalizeBreaks);
 }
 
 int URI_FUNC(ComposeQuery)(URI_CHAR * dest, const URI_TYPE(QueryList) * queryList,
-                           int maxChars, int * charsWritten) {
+        int maxChars, int * charsWritten) {
     const UriBool spaceToPlus = URI_TRUE;
     const UriBool normalizeBreaks = URI_TRUE;
 
-    return URI_FUNC(ComposeQueryEx)(dest, queryList, maxChars, charsWritten, spaceToPlus,
-                                    normalizeBreaks);
+    return URI_FUNC(ComposeQueryEx)(
+            dest, queryList, maxChars, charsWritten, spaceToPlus, normalizeBreaks);
 }
 
 int URI_FUNC(ComposeQueryEx)(URI_CHAR * dest, const URI_TYPE(QueryList) * queryList,
-                             int maxChars, int * charsWritten, UriBool spaceToPlus,
-                             UriBool normalizeBreaks) {
+        int maxChars, int * charsWritten, UriBool spaceToPlus, UriBool normalizeBreaks) {
     if ((dest == NULL) || (queryList == NULL)) {
         return URI_ERROR_NULL;
     }
@@ -123,12 +116,12 @@ int URI_FUNC(ComposeQueryEx)(URI_CHAR * dest, const URI_TYPE(QueryList) * queryL
         return URI_ERROR_OUTPUT_TOO_LARGE;
     }
 
-    return URI_FUNC(ComposeQueryEngine)(dest, queryList, maxChars, charsWritten, NULL,
-                                        spaceToPlus, normalizeBreaks);
+    return URI_FUNC(ComposeQueryEngine)(
+            dest, queryList, maxChars, charsWritten, NULL, spaceToPlus, normalizeBreaks);
 }
 
-int URI_FUNC(ComposeQueryMalloc)(URI_CHAR ** dest,
-                                 const URI_TYPE(QueryList) * queryList) {
+int URI_FUNC(ComposeQueryMalloc)(
+        URI_CHAR ** dest, const URI_TYPE(QueryList) * queryList) {
     const UriBool spaceToPlus = URI_TRUE;
     const UriBool normalizeBreaks = URI_TRUE;
 
@@ -136,16 +129,15 @@ int URI_FUNC(ComposeQueryMalloc)(URI_CHAR ** dest,
 }
 
 int URI_FUNC(ComposeQueryMallocEx)(URI_CHAR ** dest,
-                                   const URI_TYPE(QueryList) * queryList,
-                                   UriBool spaceToPlus, UriBool normalizeBreaks) {
-    return URI_FUNC(ComposeQueryMallocExMm)(dest, queryList, spaceToPlus, normalizeBreaks,
-                                            NULL);
+        const URI_TYPE(QueryList) * queryList, UriBool spaceToPlus,
+        UriBool normalizeBreaks) {
+    return URI_FUNC(ComposeQueryMallocExMm)(
+            dest, queryList, spaceToPlus, normalizeBreaks, NULL);
 }
 
 int URI_FUNC(ComposeQueryMallocExMm)(URI_CHAR ** dest,
-                                     const URI_TYPE(QueryList) * queryList,
-                                     UriBool spaceToPlus, UriBool normalizeBreaks,
-                                     UriMemoryManager * memory) {
+        const URI_TYPE(QueryList) * queryList, UriBool spaceToPlus,
+        UriBool normalizeBreaks, UriMemoryManager * memory) {
     int charsRequired;
     int res;
     URI_CHAR * queryString;
@@ -157,8 +149,8 @@ int URI_FUNC(ComposeQueryMallocExMm)(URI_CHAR ** dest,
     URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
     /* Calculate space */
-    res = URI_FUNC(ComposeQueryCharsRequiredEx)(queryList, &charsRequired, spaceToPlus,
-                                                normalizeBreaks);
+    res = URI_FUNC(ComposeQueryCharsRequiredEx)(
+            queryList, &charsRequired, spaceToPlus, normalizeBreaks);
     if (res != URI_SUCCESS) {
         return res;
     }
@@ -174,8 +166,8 @@ int URI_FUNC(ComposeQueryMallocExMm)(URI_CHAR ** dest,
     }
 
     /* Put query in */
-    res = URI_FUNC(ComposeQueryEx)(queryString, queryList, charsRequired, NULL,
-                                   spaceToPlus, normalizeBreaks);
+    res = URI_FUNC(ComposeQueryEx)(
+            queryString, queryList, charsRequired, NULL, spaceToPlus, normalizeBreaks);
     if (res != URI_SUCCESS) {
         memory->free(memory, queryString);
         return res;
@@ -186,8 +178,8 @@ int URI_FUNC(ComposeQueryMallocExMm)(URI_CHAR ** dest,
 }
 
 int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest, const URI_TYPE(QueryList) * queryList,
-                                 int maxChars, int * charsWritten, int * charsRequired,
-                                 UriBool spaceToPlus, UriBool normalizeBreaks) {
+        int maxChars, int * charsWritten, int * charsRequired, UriBool spaceToPlus,
+        UriBool normalizeBreaks) {
     UriBool firstItem = URI_TRUE;
     int ampersandLen = 0; /* increased to 1 from second item on */
     URI_CHAR * write = dest;
@@ -209,7 +201,7 @@ int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest, const URI_TYPE(QueryList) * qu
         int valueRequiredChars;
 
         if ((keyLen >= (size_t)INT_MAX / worstCase)
-            || (valueLen >= (size_t)INT_MAX / worstCase)) {
+                || (valueLen >= (size_t)INT_MAX / worstCase)) {
             return URI_ERROR_OUTPUT_TOO_LARGE;
         }
         keyRequiredChars = worstCase * (int)keyLen;
@@ -236,8 +228,8 @@ int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest, const URI_TYPE(QueryList) * qu
                 write[0] = _UT('&');
                 write++;
             }
-            write = URI_FUNC(EscapeEx)(key, key + keyLen, write, spaceToPlus,
-                                       normalizeBreaks);
+            write = URI_FUNC(EscapeEx)(
+                    key, key + keyLen, write, spaceToPlus, normalizeBreaks);
 
             if (value != NULL) {
                 if ((write - dest) + 1 + valueRequiredChars > maxChars) {
@@ -247,8 +239,8 @@ int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest, const URI_TYPE(QueryList) * qu
                 /* Copy value */
                 write[0] = _UT('=');
                 write++;
-                write = URI_FUNC(EscapeEx)(value, value + valueLen, write, spaceToPlus,
-                                           normalizeBreaks);
+                write = URI_FUNC(EscapeEx)(
+                        value, value + valueLen, write, spaceToPlus, normalizeBreaks);
             }
         }
 
@@ -273,19 +265,17 @@ int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest, const URI_TYPE(QueryList) * qu
 }
 
 UriBool URI_FUNC(AppendQueryItem)(URI_TYPE(QueryList) * *prevNext, int * itemCount,
-                                  const URI_CHAR * keyFirst, const URI_CHAR * keyAfter,
-                                  const URI_CHAR * valueFirst,
-                                  const URI_CHAR * valueAfter, UriBool plusToSpace,
-                                  UriBreakConversion breakConversion,
-                                  UriMemoryManager * memory) {
+        const URI_CHAR * keyFirst, const URI_CHAR * keyAfter, const URI_CHAR * valueFirst,
+        const URI_CHAR * valueAfter, UriBool plusToSpace,
+        UriBreakConversion breakConversion, UriMemoryManager * memory) {
     const size_t keyLen = keyAfter - keyFirst;
     const size_t valueLen = valueAfter - valueFirst;
     URI_CHAR * key;
     URI_CHAR * value;
 
     if ((prevNext == NULL) || (itemCount == NULL) || (keyFirst == NULL)
-        || (keyAfter == NULL) || (keyFirst > keyAfter) || (valueFirst > valueAfter)
-        || ((keyFirst == keyAfter) && (valueFirst == NULL) && (valueAfter == NULL))) {
+            || (keyAfter == NULL) || (keyFirst > keyAfter) || (valueFirst > valueAfter)
+            || ((keyFirst == keyAfter) && (valueFirst == NULL) && (valueAfter == NULL))) {
         return URI_TRUE;
     }
 
@@ -361,8 +351,8 @@ void URI_FUNC(FreeQueryList)(URI_TYPE(QueryList) * queryList) {
     URI_FUNC(FreeQueryListMm)(queryList, NULL);
 }
 
-int URI_FUNC(FreeQueryListMm)(URI_TYPE(QueryList) * queryList,
-                              UriMemoryManager * memory) {
+int URI_FUNC(FreeQueryListMm)(
+        URI_TYPE(QueryList) * queryList, UriMemoryManager * memory) {
     URI_CHECK_MEMORY_MANAGER(memory); /* may return */
     while (queryList != NULL) {
         URI_TYPE(QueryList) * nextBackup = queryList->next;
@@ -375,27 +365,24 @@ int URI_FUNC(FreeQueryListMm)(URI_TYPE(QueryList) * queryList,
 }
 
 int URI_FUNC(DissectQueryMalloc)(URI_TYPE(QueryList) * *dest, int * itemCount,
-                                 const URI_CHAR * first, const URI_CHAR * afterLast) {
+        const URI_CHAR * first, const URI_CHAR * afterLast) {
     const UriBool plusToSpace = URI_TRUE;
     const UriBreakConversion breakConversion = URI_BR_DONT_TOUCH;
 
-    return URI_FUNC(DissectQueryMallocEx)(dest, itemCount, first, afterLast, plusToSpace,
-                                          breakConversion);
+    return URI_FUNC(DissectQueryMallocEx)(
+            dest, itemCount, first, afterLast, plusToSpace, breakConversion);
 }
 
 int URI_FUNC(DissectQueryMallocEx)(URI_TYPE(QueryList) * *dest, int * itemCount,
-                                   const URI_CHAR * first, const URI_CHAR * afterLast,
-                                   UriBool plusToSpace,
-                                   UriBreakConversion breakConversion) {
-    return URI_FUNC(DissectQueryMallocExMm)(dest, itemCount, first, afterLast,
-                                            plusToSpace, breakConversion, NULL);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriBool plusToSpace,
+        UriBreakConversion breakConversion) {
+    return URI_FUNC(DissectQueryMallocExMm)(
+            dest, itemCount, first, afterLast, plusToSpace, breakConversion, NULL);
 }
 
 int URI_FUNC(DissectQueryMallocExMm)(URI_TYPE(QueryList) * *dest, int * itemCount,
-                                     const URI_CHAR * first, const URI_CHAR * afterLast,
-                                     UriBool plusToSpace,
-                                     UriBreakConversion breakConversion,
-                                     UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriBool plusToSpace,
+        UriBreakConversion breakConversion, UriMemoryManager * memory) {
     const URI_CHAR * walk = first;
     const URI_CHAR * keyFirst = first;
     const URI_CHAR * keyAfter = NULL;
@@ -429,9 +416,8 @@ int URI_FUNC(DissectQueryMallocExMm)(URI_TYPE(QueryList) * *dest, int * itemCoun
             }
 
             if (URI_FUNC(AppendQueryItem)(prevNext, itemsAppended, keyFirst, keyAfter,
-                                          valueFirst, valueAfter, plusToSpace,
-                                          breakConversion, memory)
-                == URI_FALSE) {
+                        valueFirst, valueAfter, plusToSpace, breakConversion, memory)
+                    == URI_FALSE) {
                 /* Free list we built */
                 *itemsAppended = 0;
                 URI_FUNC(FreeQueryListMm)(*dest, memory);
@@ -479,8 +465,8 @@ int URI_FUNC(DissectQueryMallocExMm)(URI_TYPE(QueryList) * *dest, int * itemCoun
     }
 
     if (URI_FUNC(AppendQueryItem)(prevNext, itemsAppended, keyFirst, keyAfter, valueFirst,
-                                  valueAfter, plusToSpace, breakConversion, memory)
-        == URI_FALSE) {
+                valueAfter, plusToSpace, breakConversion, memory)
+            == URI_FALSE) {
         /* Free list we built */
         *itemsAppended = 0;
         URI_FUNC(FreeQueryListMm)(*dest, memory);

--- a/src/UriQuery.c
+++ b/src/UriQuery.c
@@ -75,10 +75,13 @@ static int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest,
                                         int * charsRequired, UriBool spaceToPlus,
                                         UriBool normalizeBreaks);
 
-static UriBool URI_FUNC(AppendQueryItem)(
-    URI_TYPE(QueryList) * *prevNext, int * itemCount, const URI_CHAR * keyFirst,
-    const URI_CHAR * keyAfter, const URI_CHAR * valueFirst, const URI_CHAR * valueAfter,
-    UriBool plusToSpace, UriBreakConversion breakConversion, UriMemoryManager * memory);
+static UriBool URI_FUNC(AppendQueryItem)(URI_TYPE(QueryList) * *prevNext, int * itemCount,
+                                         const URI_CHAR * keyFirst,
+                                         const URI_CHAR * keyAfter,
+                                         const URI_CHAR * valueFirst,
+                                         const URI_CHAR * valueAfter, UriBool plusToSpace,
+                                         UriBreakConversion breakConversion,
+                                         UriMemoryManager * memory);
 
 int URI_FUNC(ComposeQueryCharsRequired)(const URI_TYPE(QueryList) * queryList,
                                         int * charsRequired) {

--- a/src/UriRecompose.c
+++ b/src/UriRecompose.c
@@ -198,7 +198,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                     /* UserInfo */
                     if (uri->userInfo.first != NULL) {
                         const size_t charsToWrite =
-                            uri->userInfo.afterLast - uri->userInfo.first;
+                                uri->userInfo.afterLast - uri->userInfo.first;
                         if (dest != NULL) {
                             // Detect and avoid integer overflow
                             if (charsToWrite > (size_t)INT_MAX - written) {
@@ -251,7 +251,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                         for (; i < 4; i++) {
                             const unsigned char value = uri->hostData.ip4->data[i];
                             const int charsToWrite =
-                                (value > 99) ? 3 : ((value > 9) ? 2 : 1);
+                                    (value > 99) ? 3 : ((value > 9) ? 2 : 1);
                             if (dest != NULL) {
                                 if (written + charsToWrite <= maxChars) {
                                     URI_CHAR text[4];
@@ -316,10 +316,10 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                             if (dest != NULL) {
                                 if (written + 2 <= maxChars) {
                                     URI_CHAR text[3];
-                                    text[0] =
-                                        URI_FUNC(HexToLetterEx)(value / 16, URI_FALSE);
-                                    text[1] =
-                                        URI_FUNC(HexToLetterEx)(value % 16, URI_FALSE);
+                                    text[0] = URI_FUNC(HexToLetterEx)(value / 16,
+                                                                      URI_FALSE);
+                                    text[1] = URI_FUNC(HexToLetterEx)(value % 16,
+                                                                      URI_FALSE);
                                     text[2] = _UT('\0');
                                     memcpy(dest + written, text, 2 * sizeof(URI_CHAR));
                                     written += 2;
@@ -427,7 +427,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                     } else if (uri->hostText.first != NULL) {
                         /* Regname */
                         const size_t charsToWrite =
-                            uri->hostText.afterLast - uri->hostText.first;
+                                uri->hostText.afterLast - uri->hostText.first;
                         if (dest != NULL) {
                             // Detect and avoid integer overflow
                             if (charsToWrite > (size_t)INT_MAX - written) {
@@ -463,7 +463,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                     /* Port */
                     if (uri->portText.first != NULL) {
                         const size_t charsToWrite =
-                            uri->portText.afterLast - uri->portText.first;
+                                uri->portText.afterLast - uri->portText.first;
                         if (dest != NULL) {
                             /* Leading ':' */
                             if (written + 1 <= maxChars) {
@@ -540,7 +540,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                     URI_TYPE(PathSegment) * walker = uri->pathHead;
                     do {
                         const size_t charsToWrite =
-                            walker->text.afterLast - walker->text.first;
+                                walker->text.afterLast - walker->text.first;
                         if (dest != NULL) {
                             // Detect and avoid integer overflow
                             if (charsToWrite > (size_t)INT_MAX - written) {
@@ -678,7 +678,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
     /* [17/19]     append fragment to result; */
                     /* clang-format on */
                     const size_t charsToWrite =
-                        uri->fragment.afterLast - uri->fragment.first;
+                            uri->fragment.afterLast - uri->fragment.first;
                     if (dest != NULL) {
                         // Detect and avoid integer overflow
                         if (charsToWrite > (size_t)INT_MAX - written) {

--- a/src/UriRecompose.c
+++ b/src/UriRecompose.c
@@ -68,22 +68,20 @@
 #  include <stdint.h>  // SIZE_MAX
 
 static int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(Uri) * uri,
-                                    int maxChars, int * charsWritten,
-                                    int * charsRequired);
+        int maxChars, int * charsWritten, int * charsRequired);
 
 int URI_FUNC(ToStringCharsRequired)(const URI_TYPE(Uri) * uri, int * charsRequired) {
     const int MAX_CHARS = ((unsigned int)-1) >> 1;
     return URI_FUNC(ToStringEngine)(NULL, uri, MAX_CHARS, NULL, charsRequired);
 }
 
-int URI_FUNC(ToString)(URI_CHAR * dest, const URI_TYPE(Uri) * uri, int maxChars,
-                       int * charsWritten) {
+int URI_FUNC(ToString)(
+        URI_CHAR * dest, const URI_TYPE(Uri) * uri, int maxChars, int * charsWritten) {
     return URI_FUNC(ToStringEngine)(dest, uri, maxChars, charsWritten, NULL);
 }
 
 static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(Uri) * uri,
-                                               int maxChars, int * charsWritten,
-                                               int * charsRequired) {
+        int maxChars, int * charsWritten, int * charsRequired) {
     int written = 0;
     if ((uri == NULL) || ((dest == NULL) && (charsRequired == NULL))) {
         if (charsWritten != NULL) {
@@ -133,7 +131,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                             }
 
                             memcpy(dest + written, uri->scheme.first,
-                                   charsToWrite * sizeof(URI_CHAR));
+                                    charsToWrite * sizeof(URI_CHAR));
                             written += charsToWrite;
                         } else {
                             dest[0] = _UT('\0');
@@ -212,7 +210,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                 }
 
                                 memcpy(dest + written, uri->userInfo.first,
-                                       charsToWrite * sizeof(URI_CHAR));
+                                        charsToWrite * sizeof(URI_CHAR));
                                 written += charsToWrite;
                             } else {
                                 dest[0] = _UT('\0');
@@ -235,8 +233,8 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                         } else {
                             // Detect and avoid integer overflow
                             if ((charsToWrite > (size_t)INT_MAX - 1)
-                                || (charsToWrite + 1
-                                    > (size_t)INT_MAX - *charsRequired)) {
+                                    || (charsToWrite + 1
+                                            > (size_t)INT_MAX - *charsRequired)) {
                                 return URI_ERROR_TOSTRING_TOO_LONG;
                             }
 
@@ -267,7 +265,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                     }
                                     text[charsToWrite] = _UT('\0');
                                     memcpy(dest + written, text,
-                                           charsToWrite * sizeof(URI_CHAR));
+                                            charsToWrite * sizeof(URI_CHAR));
                                     written += charsToWrite;
                                 } else {
                                     dest[0] = _UT('\0');
@@ -279,7 +277,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                 if (i < 3) {
                                     if (written + 1 <= maxChars) {
                                         memcpy(dest + written, _UT("."),
-                                               1 * sizeof(URI_CHAR));
+                                                1 * sizeof(URI_CHAR));
                                         written += 1;
                                     } else {
                                         dest[0] = _UT('\0');
@@ -316,10 +314,10 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                             if (dest != NULL) {
                                 if (written + 2 <= maxChars) {
                                     URI_CHAR text[3];
-                                    text[0] = URI_FUNC(HexToLetterEx)(value / 16,
-                                                                      URI_FALSE);
-                                    text[1] = URI_FUNC(HexToLetterEx)(value % 16,
-                                                                      URI_FALSE);
+                                    text[0] = URI_FUNC(HexToLetterEx)(
+                                            value / 16, URI_FALSE);
+                                    text[1] = URI_FUNC(HexToLetterEx)(
+                                            value % 16, URI_FALSE);
                                     text[2] = _UT('\0');
                                     memcpy(dest + written, text, 2 * sizeof(URI_CHAR));
                                     written += 2;
@@ -337,7 +335,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                 if (dest != NULL) {
                                     if (written + 1 <= maxChars) {
                                         memcpy(dest + written, _UT(":"),
-                                               1 * sizeof(URI_CHAR));
+                                                1 * sizeof(URI_CHAR));
                                         written += 1;
                                     } else {
                                         dest[0] = _UT('\0');
@@ -394,7 +392,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                 }
 
                                 memcpy(dest + written, uri->hostData.ipFuture.first,
-                                       charsToWrite * sizeof(URI_CHAR));
+                                        charsToWrite * sizeof(URI_CHAR));
                                 written += charsToWrite;
                             } else {
                                 dest[0] = _UT('\0');
@@ -417,8 +415,8 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                         } else {
                             // Detect and avoid integer overflow
                             if ((charsToWrite > (size_t)INT_MAX - 1 - 1)
-                                || (1 + charsToWrite + 1
-                                    > (size_t)INT_MAX - *charsRequired)) {
+                                    || (1 + charsToWrite + 1
+                                            > (size_t)INT_MAX - *charsRequired)) {
                                 return URI_ERROR_TOSTRING_TOO_LONG;
                             }
 
@@ -441,7 +439,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                 }
 
                                 memcpy(dest + written, uri->hostText.first,
-                                       charsToWrite * sizeof(URI_CHAR));
+                                        charsToWrite * sizeof(URI_CHAR));
                                 written += charsToWrite;
                             } else {
                                 dest[0] = _UT('\0');
@@ -490,7 +488,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                 }
 
                                 memcpy(dest + written, uri->portText.first,
-                                       charsToWrite * sizeof(URI_CHAR));
+                                        charsToWrite * sizeof(URI_CHAR));
                                 written += charsToWrite;
                             } else {
                                 dest[0] = _UT('\0');
@@ -502,8 +500,8 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                         } else {
                             // Detect and avoid integer overflow
                             if ((charsToWrite > (size_t)INT_MAX - 1)
-                                || (1 + charsToWrite
-                                    > (size_t)INT_MAX - *charsRequired)) {
+                                    || (1 + charsToWrite
+                                            > (size_t)INT_MAX - *charsRequired)) {
                                 return URI_ERROR_TOSTRING_TOO_LONG;
                             }
 
@@ -519,7 +517,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                 /* clang-format on */
                 /* Slash needed here? */
                 if (uri->absolutePath
-                    || ((uri->pathHead != NULL) && URI_FUNC(HasHost)(uri))) {
+                        || ((uri->pathHead != NULL) && URI_FUNC(HasHost)(uri))) {
                     if (dest != NULL) {
                         if (written + 1 <= maxChars) {
                             memcpy(dest + written, _UT("/"), 1 * sizeof(URI_CHAR));
@@ -554,7 +552,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                                 }
 
                                 memcpy(dest + written, walker->text.first,
-                                       charsToWrite * sizeof(URI_CHAR));
+                                        charsToWrite * sizeof(URI_CHAR));
                                 written += charsToWrite;
                             } else {
                                 dest[0] = _UT('\0');
@@ -577,7 +575,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                             if (dest != NULL) {
                                 if (written + 1 <= maxChars) {
                                     memcpy(dest + written, _UT("/"),
-                                           1 * sizeof(URI_CHAR));
+                                            1 * sizeof(URI_CHAR));
                                     written += 1;
                                 } else {
                                     dest[0] = _UT('\0');
@@ -632,7 +630,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                             }
 
                             memcpy(dest + written, uri->query.first,
-                                   charsToWrite * sizeof(URI_CHAR));
+                                    charsToWrite * sizeof(URI_CHAR));
                             written += charsToWrite;
                         } else {
                             dest[0] = _UT('\0');
@@ -692,7 +690,7 @@ static URI_INLINE int URI_FUNC(ToStringEngine)(URI_CHAR * dest, const URI_TYPE(U
                             }
 
                             memcpy(dest + written, uri->fragment.first,
-                                   charsToWrite * sizeof(URI_CHAR));
+                                    charsToWrite * sizeof(URI_CHAR));
                             written += charsToWrite;
                         } else {
                             dest[0] = _UT('\0');

--- a/src/UriResolve.c
+++ b/src/UriResolve.c
@@ -79,7 +79,7 @@ static URI_INLINE UriBool URI_FUNC(MergePath)(URI_TYPE(Uri) * absWork,
     /* Replace last segment ("" if trailing slash) with first of append chain */
     if (absWork->pathHead == NULL) {
         URI_TYPE(PathSegment) * const dup =
-            memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
+                memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
         if (dup == NULL) {
             return URI_FALSE; /* Raises malloc error */
         }
@@ -99,7 +99,7 @@ static URI_INLINE UriBool URI_FUNC(MergePath)(URI_TYPE(Uri) * absWork,
 
     for (;;) {
         URI_TYPE(PathSegment) * const dup =
-            memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
+                memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
         if (dup == NULL) {
             destPrev->next = NULL;
             absWork->pathTail = destPrev;
@@ -130,7 +130,7 @@ static int URI_FUNC(ResolveAbsolutePathFlag)(URI_TYPE(Uri) * absWork,
         /* Empty segment needed, instead? */
         if (absWork->pathHead == NULL) {
             URI_TYPE(PathSegment) * const segment =
-                memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
+                    memory->malloc(memory, sizeof(URI_TYPE(PathSegment)));
             if (segment == NULL) {
                 return URI_ERROR_MALLOC;
             }
@@ -179,7 +179,7 @@ static int URI_FUNC(AddBaseUriImpl)(URI_TYPE(Uri) * absDest,
     /* [00/32] if ((not strict) and (R.scheme == Base.scheme)) then */
                 /* clang-format on */
                 relSourceHasScheme =
-                    (relSource->scheme.first != NULL) ? URI_TRUE : URI_FALSE;
+                        (relSource->scheme.first != NULL) ? URI_TRUE : URI_FALSE;
                 if ((options & URI_RESOLVE_IDENTICAL_SCHEME_COMPAT)
                     && (absBase->scheme.first != NULL)
                     && (relSource->scheme.first != NULL)

--- a/src/UriResolve.c
+++ b/src/UriResolve.c
@@ -68,8 +68,7 @@
 /* Appends a relative URI to an absolute. The last path segment of
  * the absolute URI is replaced. */
 static URI_INLINE UriBool URI_FUNC(MergePath)(URI_TYPE(Uri) * absWork,
-                                              const URI_TYPE(Uri) * relAppend,
-                                              UriMemoryManager * memory) {
+        const URI_TYPE(Uri) * relAppend, UriMemoryManager * memory) {
     URI_TYPE(PathSegment) * sourceWalker;
     URI_TYPE(PathSegment) * destPrev;
     if (relAppend->pathHead == NULL) {
@@ -120,8 +119,8 @@ static URI_INLINE UriBool URI_FUNC(MergePath)(URI_TYPE(Uri) * absWork,
     return URI_TRUE;
 }
 
-static int URI_FUNC(ResolveAbsolutePathFlag)(URI_TYPE(Uri) * absWork,
-                                             UriMemoryManager * memory) {
+static int URI_FUNC(ResolveAbsolutePathFlag)(
+        URI_TYPE(Uri) * absWork, UriMemoryManager * memory) {
     if (absWork == NULL) {
         return URI_ERROR_NULL;
     }
@@ -149,10 +148,8 @@ static int URI_FUNC(ResolveAbsolutePathFlag)(URI_TYPE(Uri) * absWork,
 }
 
 static int URI_FUNC(AddBaseUriImpl)(URI_TYPE(Uri) * absDest,
-                                    const URI_TYPE(Uri) * relSource,
-                                    const URI_TYPE(Uri) * absBase,
-                                    UriResolutionOptions options,
-                                    UriMemoryManager * memory) {
+        const URI_TYPE(Uri) * relSource, const URI_TYPE(Uri) * absBase,
+        UriResolutionOptions options, UriMemoryManager * memory) {
     UriBool relSourceHasScheme;
 
     if (absDest == NULL) {
@@ -181,10 +178,10 @@ static int URI_FUNC(AddBaseUriImpl)(URI_TYPE(Uri) * absDest,
                 relSourceHasScheme =
                         (relSource->scheme.first != NULL) ? URI_TRUE : URI_FALSE;
                 if ((options & URI_RESOLVE_IDENTICAL_SCHEME_COMPAT)
-                    && (absBase->scheme.first != NULL)
-                    && (relSource->scheme.first != NULL)
-                    && (URI_FUNC(RangeEquals)(&(absBase->scheme),
-                                              &(relSource->scheme)))) {
+                        && (absBase->scheme.first != NULL)
+                        && (relSource->scheme.first != NULL)
+                        && (URI_FUNC(RangeEquals)(
+                                &(absBase->scheme), &(relSource->scheme)))) {
                     /* clang-format off */
     /* [00/32]     undefine(R.scheme); */
                     /* clang-format on */
@@ -307,8 +304,8 @@ static int URI_FUNC(AddBaseUriImpl)(URI_TYPE(Uri) * absDest,
                                 if (res != URI_SUCCESS) {
                                     return res;
                                 }
-                                if (!URI_FUNC(RemoveDotSegmentsAbsolute)(absDest,
-                                                                         memory)) {
+                                if (!URI_FUNC(RemoveDotSegmentsAbsolute)(
+                                            absDest, memory)) {
                                     return URI_ERROR_MALLOC;
                                 }
                                 /* clang-format off */
@@ -327,8 +324,8 @@ static int URI_FUNC(AddBaseUriImpl)(URI_TYPE(Uri) * absDest,
                                 /* clang-format off */
     /* [24/32]                 T.path = remove_dot_segments(T.path); */
                                 /* clang-format on */
-                                if (!URI_FUNC(RemoveDotSegmentsAbsolute)(absDest,
-                                                                         memory)) {
+                                if (!URI_FUNC(RemoveDotSegmentsAbsolute)(
+                                            absDest, memory)) {
                                     return URI_ERROR_MALLOC;
                                 }
 
@@ -370,19 +367,19 @@ static int URI_FUNC(AddBaseUriImpl)(URI_TYPE(Uri) * absDest,
 }
 
 int URI_FUNC(AddBaseUri)(URI_TYPE(Uri) * absDest, const URI_TYPE(Uri) * relSource,
-                         const URI_TYPE(Uri) * absBase) {
+        const URI_TYPE(Uri) * absBase) {
     const UriResolutionOptions options = URI_RESOLVE_STRICTLY;
     return URI_FUNC(AddBaseUriEx)(absDest, relSource, absBase, options);
 }
 
 int URI_FUNC(AddBaseUriEx)(URI_TYPE(Uri) * absDest, const URI_TYPE(Uri) * relSource,
-                           const URI_TYPE(Uri) * absBase, UriResolutionOptions options) {
+        const URI_TYPE(Uri) * absBase, UriResolutionOptions options) {
     return URI_FUNC(AddBaseUriExMm)(absDest, relSource, absBase, options, NULL);
 }
 
 int URI_FUNC(AddBaseUriExMm)(URI_TYPE(Uri) * absDest, const URI_TYPE(Uri) * relSource,
-                             const URI_TYPE(Uri) * absBase, UriResolutionOptions options,
-                             UriMemoryManager * memory) {
+        const URI_TYPE(Uri) * absBase, UriResolutionOptions options,
+        UriMemoryManager * memory) {
     int res;
 
     URI_CHECK_MEMORY_MANAGER(memory); /* may return */

--- a/src/UriSetFragment.c
+++ b/src/UriSetFragment.c
@@ -67,8 +67,8 @@
 
 #  include <assert.h>
 
-UriBool URI_FUNC(IsWellFormedFragment)(const URI_CHAR * first,
-                                       const URI_CHAR * afterLast) {
+UriBool URI_FUNC(IsWellFormedFragment)(
+        const URI_CHAR * first, const URI_CHAR * afterLast) {
     if ((first == NULL) || (afterLast == NULL)) {
         return URI_FALSE;
     }
@@ -117,7 +117,7 @@ UriBool URI_FUNC(IsWellFormedFragment)(const URI_CHAR * first,
 }
 
 int URI_FUNC(SetFragmentMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                            const URI_CHAR * afterLast, UriMemoryManager * memory) {
+        const URI_CHAR * afterLast, UriMemoryManager * memory) {
     /* Input validation (before making any changes) */
     if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
         return URI_ERROR_NULL;
@@ -126,7 +126,7 @@ int URI_FUNC(SetFragmentMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
     URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
     if ((first != NULL)
-        && (URI_FUNC(IsWellFormedFragment)(first, afterLast) == URI_FALSE)) {
+            && (URI_FUNC(IsWellFormedFragment)(first, afterLast) == URI_FALSE)) {
         return URI_ERROR_SYNTAX;
     }
 
@@ -166,8 +166,8 @@ int URI_FUNC(SetFragmentMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
     return URI_SUCCESS;
 }
 
-int URI_FUNC(SetFragment)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                          const URI_CHAR * afterLast) {
+int URI_FUNC(SetFragment)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast) {
     return URI_FUNC(SetFragmentMm)(uri, first, afterLast, NULL);
 }
 

--- a/src/UriSetHostAuto.c
+++ b/src/UriSetHostAuto.c
@@ -68,7 +68,7 @@
 #  include <assert.h>
 
 int URI_FUNC(SetHostAutoMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                            const URI_CHAR * afterLast, UriMemoryManager * memory) {
+        const URI_CHAR * afterLast, UriMemoryManager * memory) {
     if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
         return URI_ERROR_NULL;
     }
@@ -116,8 +116,8 @@ int URI_FUNC(SetHostAutoMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
     return URI_FUNC(InternalSetHostMm)(uri, hostType, first, afterLast, memory);
 }
 
-int URI_FUNC(SetHostAuto)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                          const URI_CHAR * afterLast) {
+int URI_FUNC(SetHostAuto)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast) {
     return URI_FUNC(SetHostAutoMm)(uri, first, afterLast, NULL);
 }
 

--- a/src/UriSetHostCommon.c
+++ b/src/UriSetHostCommon.c
@@ -114,7 +114,7 @@ int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri, UriHostType hostType,
         } break;
         case URI_HOST_TYPE_IPFUTURE: {
             const int res =
-                URI_FUNC(IsWellFormedHostIpFutureMm)(first, afterLast, memory);
+                    URI_FUNC(IsWellFormedHostIpFutureMm)(first, afterLast, memory);
             assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX)
                    || (res == URI_ERROR_MALLOC));
             if (res != URI_SUCCESS) {
@@ -171,7 +171,7 @@ int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri, UriHostType hostType,
             }
 
             const UriBool success =
-                URI_FUNC(EnsureThatPathIsNotMistakenForHost)(uri, memory);
+                    URI_FUNC(EnsureThatPathIsNotMistakenForHost)(uri, memory);
             return (success == URI_TRUE) ? URI_SUCCESS : URI_ERROR_MALLOC;
         }
 
@@ -210,7 +210,7 @@ int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri, UriHostType hostType,
         }
 
         const int res =
-            URI_FUNC(ParseIpFourAddress)(uri->hostData.ip4->data, first, afterLast);
+                URI_FUNC(ParseIpFourAddress)(uri->hostData.ip4->data, first, afterLast);
 #  if defined(NDEBUG)
         (void)res; /* i.e. mark as unused */
 #  else
@@ -223,8 +223,8 @@ int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri, UriHostType hostType,
             return URI_ERROR_MALLOC;
         }
 
-        const int res =
-            URI_FUNC(ParseIpSixAddressMm)(uri->hostData.ip6, first, afterLast, memory);
+        const int res = URI_FUNC(ParseIpSixAddressMm)(uri->hostData.ip6, first, afterLast,
+                                                      memory);
         assert((res == URI_SUCCESS)
                || (res == URI_ERROR_MALLOC)); /* because checked for
                                                  well-formedness earlier */

--- a/src/UriSetHostCommon.c
+++ b/src/UriSetHostCommon.c
@@ -76,8 +76,7 @@
 #  include <assert.h>
 
 int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri, UriHostType hostType,
-                                const URI_CHAR * first, const URI_CHAR * afterLast,
-                                UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     /* Superficial input validation (before making any changes) */
     if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
         return URI_ERROR_NULL;
@@ -107,7 +106,7 @@ int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri, UriHostType hostType,
         case URI_HOST_TYPE_IP6: {
             const int res = URI_FUNC(IsWellFormedHostIp6Mm)(first, afterLast, memory);
             assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX)
-                   || (res == URI_ERROR_MALLOC));
+                    || (res == URI_ERROR_MALLOC));
             if (res != URI_SUCCESS) {
                 return res;
             }
@@ -116,7 +115,7 @@ int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri, UriHostType hostType,
             const int res =
                     URI_FUNC(IsWellFormedHostIpFutureMm)(first, afterLast, memory);
             assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX)
-                   || (res == URI_ERROR_MALLOC));
+                    || (res == URI_ERROR_MALLOC));
             if (res != URI_SUCCESS) {
                 return res;
             }
@@ -140,14 +139,14 @@ int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri, UriHostType hostType,
         uri->hostText.afterLast = NULL;
 
         if ((uri->owner == URI_TRUE)
-            && (uri->hostData.ipFuture.first != uri->hostData.ipFuture.afterLast)) {
+                && (uri->hostData.ipFuture.first != uri->hostData.ipFuture.afterLast)) {
             memory->free(memory, (URI_CHAR *)uri->hostData.ipFuture.first);
         }
         uri->hostData.ipFuture.first = NULL;
         uri->hostData.ipFuture.afterLast = NULL;
     } else if (uri->hostText.first != NULL) {
         if ((uri->owner == URI_TRUE)
-            && (uri->hostText.first != uri->hostText.afterLast)) {
+                && (uri->hostText.first != uri->hostText.afterLast)) {
             memory->free(memory, (URI_CHAR *)uri->hostText.first);
         }
         uri->hostText.first = NULL;
@@ -223,11 +222,11 @@ int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri, UriHostType hostType,
             return URI_ERROR_MALLOC;
         }
 
-        const int res = URI_FUNC(ParseIpSixAddressMm)(uri->hostData.ip6, first, afterLast,
-                                                      memory);
+        const int res = URI_FUNC(ParseIpSixAddressMm)(
+                uri->hostData.ip6, first, afterLast, memory);
         assert((res == URI_SUCCESS)
-               || (res == URI_ERROR_MALLOC)); /* because checked for
-                                                 well-formedness earlier */
+                || (res == URI_ERROR_MALLOC)); /* because checked for
+                                                  well-formedness earlier */
         if (res != URI_SUCCESS) {
             return res;
         }

--- a/src/UriSetHostCommon.h
+++ b/src/UriSetHostCommon.h
@@ -55,9 +55,9 @@
 #    endif
 /* Only one pass for each encoding */
 #  elif (defined(URI_PASS_ANSI) && !defined(URI_SET_HOST_COMMON_H_ANSI) \
-         && defined(URI_ENABLE_ANSI)) \
+          && defined(URI_ENABLE_ANSI)) \
           || (defined(URI_PASS_UNICODE) && !defined(URI_SET_HOST_COMMON_H_UNICODE) \
-              && defined(URI_ENABLE_UNICODE))
+                  && defined(URI_ENABLE_UNICODE))
 #    ifdef URI_PASS_ANSI
 #      define URI_SET_HOST_COMMON_H_ANSI 1
 #      include <uriparser/UriDefsAnsi.h>
@@ -67,8 +67,7 @@
 #    endif
 
 int URI_FUNC(InternalSetHostMm)(URI_TYPE(Uri) * uri, UriHostType hostType,
-                                const URI_CHAR * first, const URI_CHAR * afterLast,
-                                UriMemoryManager * memory);
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 #  endif
 #endif

--- a/src/UriSetHostCommon.h
+++ b/src/UriSetHostCommon.h
@@ -37,8 +37,8 @@
  */
 
 #if (defined(URI_PASS_ANSI) && !defined(URI_SET_HOST_COMMON_H_ANSI)) \
-    || (defined(URI_PASS_UNICODE) && !defined(URI_SET_HOST_COMMON_H_UNICODE)) \
-    || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
+        || (defined(URI_PASS_UNICODE) && !defined(URI_SET_HOST_COMMON_H_UNICODE)) \
+        || (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
 /* What encodings are enabled? */
 #  include <uriparser/UriDefsConfig.h>
 #  if (!defined(URI_PASS_ANSI) && !defined(URI_PASS_UNICODE))
@@ -56,8 +56,8 @@
 /* Only one pass for each encoding */
 #  elif (defined(URI_PASS_ANSI) && !defined(URI_SET_HOST_COMMON_H_ANSI) \
          && defined(URI_ENABLE_ANSI)) \
-      || (defined(URI_PASS_UNICODE) && !defined(URI_SET_HOST_COMMON_H_UNICODE) \
-          && defined(URI_ENABLE_UNICODE))
+          || (defined(URI_PASS_UNICODE) && !defined(URI_SET_HOST_COMMON_H_UNICODE) \
+              && defined(URI_ENABLE_UNICODE))
 #    ifdef URI_PASS_ANSI
 #      define URI_SET_HOST_COMMON_H_ANSI 1
 #      include <uriparser/UriDefsAnsi.h>

--- a/src/UriSetHostIp4.c
+++ b/src/UriSetHostIp4.c
@@ -66,8 +66,8 @@
 #    include "UriSetHostCommon.h"
 #  endif
 
-UriBool URI_FUNC(IsWellFormedHostIp4)(const URI_CHAR * first,
-                                      const URI_CHAR * afterLast) {
+UriBool URI_FUNC(IsWellFormedHostIp4)(
+        const URI_CHAR * first, const URI_CHAR * afterLast) {
     if ((first == NULL) || (afterLast == NULL)) {
         return URI_FALSE;
     }
@@ -79,12 +79,12 @@ UriBool URI_FUNC(IsWellFormedHostIp4)(const URI_CHAR * first,
 }
 
 int URI_FUNC(SetHostIp4Mm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                           const URI_CHAR * afterLast, UriMemoryManager * memory) {
+        const URI_CHAR * afterLast, UriMemoryManager * memory) {
     return URI_FUNC(InternalSetHostMm)(uri, URI_HOST_TYPE_IP4, first, afterLast, memory);
 }
 
-int URI_FUNC(SetHostIp4)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                         const URI_CHAR * afterLast) {
+int URI_FUNC(SetHostIp4)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast) {
     return URI_FUNC(SetHostIp4Mm)(uri, first, afterLast, NULL);
 }
 

--- a/src/UriSetHostIp4.c
+++ b/src/UriSetHostIp4.c
@@ -74,8 +74,8 @@ UriBool URI_FUNC(IsWellFormedHostIp4)(const URI_CHAR * first,
 
     unsigned char octetOutput[4];
     return (URI_FUNC(ParseIpFourAddress)(octetOutput, first, afterLast) == URI_SUCCESS)
-               ? URI_TRUE
-               : URI_FALSE;
+                   ? URI_TRUE
+                   : URI_FALSE;
 }
 
 int URI_FUNC(SetHostIp4Mm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,

--- a/src/UriSetHostIp6.c
+++ b/src/UriSetHostIp6.c
@@ -73,7 +73,7 @@
                        */
 
 int URI_FUNC(ParseIpSixAddressMm)(UriIp6 * output, const URI_CHAR * first,
-                                  const URI_CHAR * afterLast, UriMemoryManager * memory) {
+        const URI_CHAR * afterLast, UriMemoryManager * memory) {
     /* NOTE: output is allowed to be NULL */
     if ((first == NULL) || (afterLast == NULL)) {
         return URI_ERROR_NULL;
@@ -107,7 +107,7 @@ int URI_FUNC(ParseIpSixAddressMm)(UriIp6 * output, const URI_CHAR * first,
 
     memcpy(candidate + 3, first, inputLenChars * sizeof(URI_CHAR));
     memcpy(candidate + 3 + inputLenChars, _UT("]"),
-           2 * sizeof(URI_CHAR)); /* includes zero terminator */
+            2 * sizeof(URI_CHAR)); /* includes zero terminator */
 
     /* Parse as an RFC 3986 URI */
     const size_t candidateLenChars = 3 + inputLenChars + 1;
@@ -116,7 +116,7 @@ int URI_FUNC(ParseIpSixAddressMm)(UriIp6 * output, const URI_CHAR * first,
             &uri, candidate, candidate + candidateLenChars, NULL, memory);
 
     assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX)
-           || (res == URI_ERROR_MALLOC));
+            || (res == URI_ERROR_MALLOC));
 
     if (res == URI_SUCCESS) {
         assert(uri.hostData.ip6 != NULL);
@@ -131,13 +131,13 @@ int URI_FUNC(ParseIpSixAddressMm)(UriIp6 * output, const URI_CHAR * first,
     return res;
 }
 
-int URI_FUNC(ParseIpSixAddress)(UriIp6 * output, const URI_CHAR * first,
-                                const URI_CHAR * afterLast) {
+int URI_FUNC(ParseIpSixAddress)(
+        UriIp6 * output, const URI_CHAR * first, const URI_CHAR * afterLast) {
     return URI_FUNC(ParseIpSixAddressMm)(output, first, afterLast, NULL);
 }
 
-int URI_FUNC(IsWellFormedHostIp6Mm)(const URI_CHAR * first, const URI_CHAR * afterLast,
-                                    UriMemoryManager * memory) {
+int URI_FUNC(IsWellFormedHostIp6Mm)(
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     return URI_FUNC(ParseIpSixAddressMm)(NULL, first, afterLast, memory);
 }
 
@@ -146,12 +146,12 @@ int URI_FUNC(IsWellFormedHostIp6)(const URI_CHAR * first, const URI_CHAR * after
 }
 
 int URI_FUNC(SetHostIp6Mm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                           const URI_CHAR * afterLast, UriMemoryManager * memory) {
+        const URI_CHAR * afterLast, UriMemoryManager * memory) {
     return URI_FUNC(InternalSetHostMm)(uri, URI_HOST_TYPE_IP6, first, afterLast, memory);
 }
 
-int URI_FUNC(SetHostIp6)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                         const URI_CHAR * afterLast) {
+int URI_FUNC(SetHostIp6)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast) {
     return URI_FUNC(SetHostIp6Mm)(uri, first, afterLast, NULL);
 }
 

--- a/src/UriSetHostIp6.c
+++ b/src/UriSetHostIp6.c
@@ -113,7 +113,7 @@ int URI_FUNC(ParseIpSixAddressMm)(UriIp6 * output, const URI_CHAR * first,
     const size_t candidateLenChars = 3 + inputLenChars + 1;
     URI_TYPE(Uri) uri;
     const int res = URI_FUNC(ParseSingleUriExMm)(
-        &uri, candidate, candidate + candidateLenChars, NULL, memory);
+            &uri, candidate, candidate + candidateLenChars, NULL, memory);
 
     assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX)
            || (res == URI_ERROR_MALLOC));

--- a/src/UriSetHostIpFuture.c
+++ b/src/UriSetHostIpFuture.c
@@ -109,7 +109,7 @@ int URI_FUNC(IsWellFormedHostIpFutureMm)(const URI_CHAR * first,
     }
 
     URI_CHAR * const candidate =
-        memory->malloc(memory, (candidateLenChars + 1) * sizeof(URI_CHAR));
+            memory->malloc(memory, (candidateLenChars + 1) * sizeof(URI_CHAR));
 
     if (candidate == NULL) {
         return URI_ERROR_MALLOC;
@@ -123,7 +123,7 @@ int URI_FUNC(IsWellFormedHostIpFutureMm)(const URI_CHAR * first,
     /* Parse as an RFC 3986 URI */
     URI_TYPE(Uri) uri;
     const int res = URI_FUNC(ParseSingleUriExMm)(
-        &uri, candidate, candidate + candidateLenChars, NULL, memory);
+            &uri, candidate, candidate + candidateLenChars, NULL, memory);
 
     assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX)
            || (res == URI_ERROR_MALLOC));

--- a/src/UriSetHostIpFuture.c
+++ b/src/UriSetHostIpFuture.c
@@ -68,9 +68,8 @@
 #  include <assert.h>
 #  include <string.h> /* for memcpy */
 
-int URI_FUNC(IsWellFormedHostIpFutureMm)(const URI_CHAR * first,
-                                         const URI_CHAR * afterLast,
-                                         UriMemoryManager * memory) {
+int URI_FUNC(IsWellFormedHostIpFutureMm)(
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     if ((first == NULL) || (afterLast == NULL)) {
         return URI_ERROR_NULL;
     }
@@ -118,7 +117,7 @@ int URI_FUNC(IsWellFormedHostIpFutureMm)(const URI_CHAR * first,
     memcpy(candidate, _UT("//["), 3 * sizeof(URI_CHAR));
     memcpy(candidate + 3, first, inputLenChars * sizeof(URI_CHAR));
     memcpy(candidate + 3 + inputLenChars, _UT("]"),
-           2 * sizeof(URI_CHAR)); /* includes zero terminator */
+            2 * sizeof(URI_CHAR)); /* includes zero terminator */
 
     /* Parse as an RFC 3986 URI */
     URI_TYPE(Uri) uri;
@@ -126,7 +125,7 @@ int URI_FUNC(IsWellFormedHostIpFutureMm)(const URI_CHAR * first,
             &uri, candidate, candidate + candidateLenChars, NULL, memory);
 
     assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX)
-           || (res == URI_ERROR_MALLOC));
+            || (res == URI_ERROR_MALLOC));
 
     if (res == URI_SUCCESS) {
         assert(uri.hostData.ipFuture.first != NULL);
@@ -138,19 +137,19 @@ int URI_FUNC(IsWellFormedHostIpFutureMm)(const URI_CHAR * first,
     return res;
 }
 
-int URI_FUNC(IsWellFormedHostIpFuture)(const URI_CHAR * first,
-                                       const URI_CHAR * afterLast) {
+int URI_FUNC(IsWellFormedHostIpFuture)(
+        const URI_CHAR * first, const URI_CHAR * afterLast) {
     return URI_FUNC(IsWellFormedHostIpFutureMm)(first, afterLast, NULL);
 }
 
 int URI_FUNC(SetHostIpFutureMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                                const URI_CHAR * afterLast, UriMemoryManager * memory) {
-    return URI_FUNC(InternalSetHostMm)(uri, URI_HOST_TYPE_IPFUTURE, first, afterLast,
-                                       memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    return URI_FUNC(InternalSetHostMm)(
+            uri, URI_HOST_TYPE_IPFUTURE, first, afterLast, memory);
 }
 
-int URI_FUNC(SetHostIpFuture)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                              const URI_CHAR * afterLast) {
+int URI_FUNC(SetHostIpFuture)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast) {
     return URI_FUNC(SetHostIpFutureMm)(uri, first, afterLast, NULL);
 }
 

--- a/src/UriSetHostRegName.c
+++ b/src/UriSetHostRegName.c
@@ -66,8 +66,8 @@
 #    include "UriSets.h"
 #  endif
 
-UriBool URI_FUNC(IsWellFormedHostRegName)(const URI_CHAR * first,
-                                          const URI_CHAR * afterLast) {
+UriBool URI_FUNC(IsWellFormedHostRegName)(
+        const URI_CHAR * first, const URI_CHAR * afterLast) {
     if ((first == NULL) || (afterLast == NULL)) {
         return URI_FALSE;
     }
@@ -111,13 +111,13 @@ UriBool URI_FUNC(IsWellFormedHostRegName)(const URI_CHAR * first,
 }
 
 int URI_FUNC(SetHostRegNameMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                               const URI_CHAR * afterLast, UriMemoryManager * memory) {
-    return URI_FUNC(InternalSetHostMm)(uri, URI_HOST_TYPE_REGNAME, first, afterLast,
-                                       memory);
+        const URI_CHAR * afterLast, UriMemoryManager * memory) {
+    return URI_FUNC(InternalSetHostMm)(
+            uri, URI_HOST_TYPE_REGNAME, first, afterLast, memory);
 }
 
-int URI_FUNC(SetHostRegName)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                             const URI_CHAR * afterLast) {
+int URI_FUNC(SetHostRegName)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast) {
     return URI_FUNC(SetHostRegNameMm)(uri, first, afterLast, NULL);
 }
 

--- a/src/UriSetPath.c
+++ b/src/UriSetPath.c
@@ -220,7 +220,7 @@ static int URI_FUNC(InternalSetPath)(URI_TYPE(Uri) * destUri, const URI_CHAR * f
     }
 
     URI_CHAR * const candidate =
-        memory->malloc(memory, (candidateLenChars + 1) * sizeof(URI_CHAR));
+            memory->malloc(memory, (candidateLenChars + 1) * sizeof(URI_CHAR));
 
     if (candidate == NULL) {
         return URI_ERROR_MALLOC;

--- a/src/UriSetPath.c
+++ b/src/UriSetPath.c
@@ -67,8 +67,8 @@
 
 #  include <assert.h>
 
-UriBool URI_FUNC(IsWellFormedPath)(const URI_CHAR * first, const URI_CHAR * afterLast,
-                                   UriBool hasHost) {
+UriBool URI_FUNC(IsWellFormedPath)(
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriBool hasHost) {
     if ((first == NULL) || (afterLast == NULL)) {
         return URI_FALSE;
     }
@@ -142,8 +142,8 @@ UriBool URI_FUNC(IsWellFormedPath)(const URI_CHAR * first, const URI_CHAR * afte
     return URI_TRUE;
 }
 
-static void URI_FUNC(DropEmptyFirstPathSegment)(URI_TYPE(Uri) * uri,
-                                                UriMemoryManager * memory) {
+static void URI_FUNC(DropEmptyFirstPathSegment)(
+        URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
     assert(uri != NULL);
     assert(memory != NULL);
     assert(uri->pathHead != NULL);
@@ -162,13 +162,13 @@ static void URI_FUNC(DropEmptyFirstPathSegment)(URI_TYPE(Uri) * uri,
  * This function checks for a leading empty path segment (that would have the "visual
  * effect" of a leading slash during stringification) and transforms it into .absolutePath
  * == URI_TRUE instead, if present. */
-static void URI_FUNC(TransformEmptyLeadPathSegments)(URI_TYPE(Uri) * uri,
-                                                     UriMemoryManager * memory) {
+static void URI_FUNC(TransformEmptyLeadPathSegments)(
+        URI_TYPE(Uri) * uri, UriMemoryManager * memory) {
     assert(uri != NULL);
     assert(memory != NULL);
 
     if ((URI_FUNC(HasHost)(uri) == URI_TRUE) || (uri->pathHead == NULL)
-        || (uri->pathHead->text.first != uri->pathHead->text.afterLast)) {
+            || (uri->pathHead->text.first != uri->pathHead->text.afterLast)) {
         return; /* i.e. nothing to do */
     }
 
@@ -180,8 +180,7 @@ static void URI_FUNC(TransformEmptyLeadPathSegments)(URI_TYPE(Uri) * uri,
 }
 
 static int URI_FUNC(InternalSetPath)(URI_TYPE(Uri) * destUri, const URI_CHAR * first,
-                                     const URI_CHAR * afterLast,
-                                     UriMemoryManager * memory) {
+        const URI_CHAR * afterLast, UriMemoryManager * memory) {
     assert(destUri != NULL);
     assert(first != NULL);
     assert(afterLast != NULL);
@@ -232,10 +231,10 @@ static int URI_FUNC(InternalSetPath)(URI_TYPE(Uri) * destUri, const URI_CHAR * f
 
     /* Parse as an RFC 3986 URI */
     URI_TYPE(Uri) tempUri;
-    int res = URI_FUNC(ParseSingleUriExMm)(&tempUri, candidate,
-                                           candidate + candidateLenChars, NULL, memory);
+    int res = URI_FUNC(ParseSingleUriExMm)(
+            &tempUri, candidate, candidate + candidateLenChars, NULL, memory);
     assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX)
-           || (res == URI_ERROR_MALLOC));
+            || (res == URI_ERROR_MALLOC));
     if (res != URI_SUCCESS) {
         memory->free(memory, candidate);
         return res;
@@ -290,7 +289,7 @@ static int URI_FUNC(InternalSetPath)(URI_TYPE(Uri) * destUri, const URI_CHAR * f
 }
 
 int URI_FUNC(SetPathMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                        const URI_CHAR * afterLast, UriMemoryManager * memory) {
+        const URI_CHAR * afterLast, UriMemoryManager * memory) {
     /* Input validation (before making any changes) */
     if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
         return URI_ERROR_NULL;
@@ -299,8 +298,8 @@ int URI_FUNC(SetPathMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
     URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
     if ((first != NULL)
-        && (URI_FUNC(IsWellFormedPath)(first, afterLast, URI_FUNC(HasHost)(uri))
-            == URI_FALSE)) {
+            && (URI_FUNC(IsWellFormedPath)(first, afterLast, URI_FUNC(HasHost)(uri))
+                    == URI_FALSE)) {
         return URI_ERROR_SYNTAX;
     }
 
@@ -331,12 +330,12 @@ int URI_FUNC(SetPathMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
     /* Apply new value */
     res = URI_FUNC(InternalSetPath)(uri, first, afterLast, memory);
     assert((res == URI_SUCCESS) || (res == URI_ERROR_SYNTAX)
-           || (res == URI_ERROR_MALLOC));
+            || (res == URI_ERROR_MALLOC));
     return res;
 }
 
-int URI_FUNC(SetPath)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                      const URI_CHAR * afterLast) {
+int URI_FUNC(SetPath)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast) {
     return URI_FUNC(SetPathMm)(uri, first, afterLast, NULL);
 }
 

--- a/src/UriSetPort.c
+++ b/src/UriSetPort.c
@@ -86,7 +86,7 @@ UriBool URI_FUNC(IsWellFormedPort)(const URI_CHAR * first, const URI_CHAR * afte
 }
 
 int URI_FUNC(SetPortTextMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                            const URI_CHAR * afterLast, UriMemoryManager * memory) {
+        const URI_CHAR * afterLast, UriMemoryManager * memory) {
     /* Input validation (before making any changes) */
     if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
         return URI_ERROR_NULL;
@@ -141,8 +141,8 @@ int URI_FUNC(SetPortTextMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
     return URI_SUCCESS;
 }
 
-int URI_FUNC(SetPortText)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                          const URI_CHAR * afterLast) {
+int URI_FUNC(SetPortText)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast) {
     return URI_FUNC(SetPortTextMm)(uri, first, afterLast, NULL);
 }
 

--- a/src/UriSetQuery.c
+++ b/src/UriSetQuery.c
@@ -116,7 +116,7 @@ UriBool URI_FUNC(IsWellFormedQuery)(const URI_CHAR * first, const URI_CHAR * aft
 }
 
 int URI_FUNC(SetQueryMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                         const URI_CHAR * afterLast, UriMemoryManager * memory) {
+        const URI_CHAR * afterLast, UriMemoryManager * memory) {
     /* Input validation (before making any changes) */
     if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
         return URI_ERROR_NULL;
@@ -164,8 +164,8 @@ int URI_FUNC(SetQueryMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
     return URI_SUCCESS;
 }
 
-int URI_FUNC(SetQuery)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                       const URI_CHAR * afterLast) {
+int URI_FUNC(SetQuery)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast) {
     return URI_FUNC(SetQueryMm)(uri, first, afterLast, NULL);
 }
 

--- a/src/UriSetScheme.c
+++ b/src/UriSetScheme.c
@@ -109,7 +109,7 @@ UriBool URI_FUNC(IsWellFormedScheme)(const URI_CHAR * first, const URI_CHAR * af
 }
 
 int URI_FUNC(SetSchemeMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                          const URI_CHAR * afterLast, UriMemoryManager * memory) {
+        const URI_CHAR * afterLast, UriMemoryManager * memory) {
     /* Input validation (before making any changes) */
     if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
         return URI_ERROR_NULL;
@@ -118,7 +118,7 @@ int URI_FUNC(SetSchemeMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
     URI_CHECK_MEMORY_MANAGER(memory); /* may return */
 
     if ((first != NULL)
-        && (URI_FUNC(IsWellFormedScheme)(first, afterLast) == URI_FALSE)) {
+            && (URI_FUNC(IsWellFormedScheme)(first, afterLast) == URI_FALSE)) {
         return URI_ERROR_SYNTAX;
     }
 
@@ -160,8 +160,8 @@ int URI_FUNC(SetSchemeMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
     return URI_SUCCESS;
 }
 
-int URI_FUNC(SetScheme)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                        const URI_CHAR * afterLast) {
+int URI_FUNC(SetScheme)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast) {
     return URI_FUNC(SetSchemeMm)(uri, first, afterLast, NULL);
 }
 

--- a/src/UriSetUserInfo.c
+++ b/src/UriSetUserInfo.c
@@ -67,8 +67,8 @@
 
 #  include <assert.h>
 
-UriBool URI_FUNC(IsWellFormedUserInfo)(const URI_CHAR * first,
-                                       const URI_CHAR * afterLast) {
+UriBool URI_FUNC(IsWellFormedUserInfo)(
+        const URI_CHAR * first, const URI_CHAR * afterLast) {
     if ((first == NULL) || (afterLast == NULL)) {
         return URI_FALSE;
     }
@@ -116,7 +116,7 @@ UriBool URI_FUNC(IsWellFormedUserInfo)(const URI_CHAR * first,
 }
 
 int URI_FUNC(SetUserInfoMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                            const URI_CHAR * afterLast, UriMemoryManager * memory) {
+        const URI_CHAR * afterLast, UriMemoryManager * memory) {
     /* Input validation (before making any changes) */
     if ((uri == NULL) || ((first == NULL) != (afterLast == NULL))) {
         return URI_ERROR_NULL;
@@ -132,7 +132,7 @@ int URI_FUNC(SetUserInfoMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
     }
 
     if ((first != NULL)
-        && (URI_FUNC(IsWellFormedUserInfo)(first, afterLast) == URI_FALSE)) {
+            && (URI_FUNC(IsWellFormedUserInfo)(first, afterLast) == URI_FALSE)) {
         return URI_ERROR_SYNTAX;
     }
 
@@ -172,8 +172,8 @@ int URI_FUNC(SetUserInfoMm)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
     return URI_SUCCESS;
 }
 
-int URI_FUNC(SetUserInfo)(URI_TYPE(Uri) * uri, const URI_CHAR * first,
-                          const URI_CHAR * afterLast) {
+int URI_FUNC(SetUserInfo)(
+        URI_TYPE(Uri) * uri, const URI_CHAR * first, const URI_CHAR * afterLast) {
     return URI_FUNC(SetUserInfoMm)(uri, first, afterLast, NULL);
 }
 

--- a/src/UriShorten.c
+++ b/src/UriShorten.c
@@ -66,9 +66,7 @@
 #  endif
 
 static URI_INLINE UriBool URI_FUNC(AppendSegment)(URI_TYPE(Uri) * uri,
-                                                  const URI_CHAR * first,
-                                                  const URI_CHAR * afterLast,
-                                                  UriMemoryManager * memory) {
+        const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory) {
     /* Create segment */
     URI_TYPE(PathSegment) * segment =
             memory->malloc(memory, 1 * sizeof(URI_TYPE(PathSegment)));
@@ -90,12 +88,13 @@ static URI_INLINE UriBool URI_FUNC(AppendSegment)(URI_TYPE(Uri) * uri,
     return URI_TRUE;
 }
 
-static URI_INLINE UriBool URI_FUNC(EqualsAuthority)(const URI_TYPE(Uri) * first,
-                                                    const URI_TYPE(Uri) * second) {
+static URI_INLINE UriBool URI_FUNC(EqualsAuthority)(
+        const URI_TYPE(Uri) * first, const URI_TYPE(Uri) * second) {
     /* IPv4 */
     if (first->hostData.ip4 != NULL) {
         return ((second->hostData.ip4 != NULL)
-                && !memcmp(first->hostData.ip4->data, second->hostData.ip4->data, 4))
+                       && !memcmp(
+                               first->hostData.ip4->data, second->hostData.ip4->data, 4))
                        ? URI_TRUE
                        : URI_FALSE;
     }
@@ -103,7 +102,8 @@ static URI_INLINE UriBool URI_FUNC(EqualsAuthority)(const URI_TYPE(Uri) * first,
     /* IPv6 */
     if (first->hostData.ip6 != NULL) {
         return ((second->hostData.ip6 != NULL)
-                && !memcmp(first->hostData.ip6->data, second->hostData.ip6->data, 16))
+                       && !memcmp(
+                               first->hostData.ip6->data, second->hostData.ip6->data, 16))
                        ? URI_TRUE
                        : URI_FALSE;
     }
@@ -111,8 +111,8 @@ static URI_INLINE UriBool URI_FUNC(EqualsAuthority)(const URI_TYPE(Uri) * first,
     /* IPvFuture */
     if (first->hostData.ipFuture.first != NULL) {
         return ((second->hostData.ipFuture.first != NULL)
-                && URI_FUNC(RangeEquals)(&first->hostData.ipFuture,
-                                         &second->hostData.ipFuture))
+                       && URI_FUNC(RangeEquals)(
+                               &first->hostData.ipFuture, &second->hostData.ipFuture))
                        ? URI_TRUE
                        : URI_FALSE;
     }
@@ -122,10 +122,8 @@ static URI_INLINE UriBool URI_FUNC(EqualsAuthority)(const URI_TYPE(Uri) * first,
 }
 
 static int URI_FUNC(RemoveBaseUriImpl)(URI_TYPE(Uri) * dest,
-                                       const URI_TYPE(Uri) * absSource,
-                                       const URI_TYPE(Uri) * absBase,
-                                       UriBool domainRootMode,
-                                       UriMemoryManager * memory) {
+        const URI_TYPE(Uri) * absSource, const URI_TYPE(Uri) * absBase,
+        UriBool domainRootMode, UriMemoryManager * memory) {
     if (dest == NULL) {
         return URI_ERROR_NULL;
     }
@@ -254,12 +252,12 @@ static int URI_FUNC(RemoveBaseUriImpl)(URI_TYPE(Uri) * dest,
     /* [22/50]          while (first(A.path) == first(Base.path)) do */
                             /* clang-format on */
                             while ((sourceSeg != NULL) && (baseSeg != NULL)
-                                   && URI_FUNC(RangeEquals)(&sourceSeg->text,
-                                                            &baseSeg->text)
-                                   && !((sourceSeg->text.first
-                                         == sourceSeg->text.afterLast)
-                                        && ((sourceSeg->next == NULL)
-                                            != (baseSeg->next == NULL)))) {
+                                    && URI_FUNC(RangeEquals)(
+                                            &sourceSeg->text, &baseSeg->text)
+                                    && !((sourceSeg->text.first
+                                                 == sourceSeg->text.afterLast)
+                                            && ((sourceSeg->next == NULL)
+                                                    != (baseSeg->next == NULL)))) {
                                 /* clang-format off */
     /* [23/50]             A.path++; */
                                 /* clang-format on */
@@ -284,8 +282,7 @@ static int URI_FUNC(RemoveBaseUriImpl)(URI_TYPE(Uri) * dest,
     /* [28/50]             T.path += "../"; */
                                 /* clang-format on */
                                 if (!URI_FUNC(AppendSegment)(dest, URI_FUNC(ConstParent),
-                                                             URI_FUNC(ConstParent) + 2,
-                                                             memory)) {
+                                            URI_FUNC(ConstParent) + 2, memory)) {
                                     return URI_ERROR_MALLOC;
                                 }
                                 /* clang-format off */
@@ -320,8 +317,8 @@ static int URI_FUNC(RemoveBaseUriImpl)(URI_TYPE(Uri) * dest,
                                         /* clang-format off */
     /* [34/50]                   T.path += "./"; */
                                         /* clang-format on */
-                                        if (!URI_FUNC(AppendSegment)(
-                                                    dest, URI_FUNC(ConstPwd),
+                                        if (!URI_FUNC(AppendSegment)(dest,
+                                                    URI_FUNC(ConstPwd),
                                                     URI_FUNC(ConstPwd) + 1, memory)) {
                                             return URI_ERROR_MALLOC;
                                         }
@@ -333,8 +330,8 @@ static int URI_FUNC(RemoveBaseUriImpl)(URI_TYPE(Uri) * dest,
                                         /* clang-format off */
     /* [36/50]                   T.path += "/."; */
                                         /* clang-format on */
-                                        if (!URI_FUNC(AppendSegment)(
-                                                    dest, URI_FUNC(ConstPwd),
+                                        if (!URI_FUNC(AppendSegment)(dest,
+                                                    URI_FUNC(ConstPwd),
                                                     URI_FUNC(ConstPwd) + 1, memory)) {
                                             return URI_ERROR_MALLOC;
                                         }
@@ -350,8 +347,7 @@ static int URI_FUNC(RemoveBaseUriImpl)(URI_TYPE(Uri) * dest,
     /* [39/50]             T.path += first(A.path); */
                                 /* clang-format on */
                                 if (!URI_FUNC(AppendSegment)(dest, sourceSeg->text.first,
-                                                             sourceSeg->text.afterLast,
-                                                             memory)) {
+                                            sourceSeg->text.afterLast, memory)) {
                                     return URI_ERROR_MALLOC;
                                 }
                                 /* clang-format off */
@@ -405,13 +401,13 @@ static int URI_FUNC(RemoveBaseUriImpl)(URI_TYPE(Uri) * dest,
 }
 
 int URI_FUNC(RemoveBaseUri)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * absSource,
-                            const URI_TYPE(Uri) * absBase, UriBool domainRootMode) {
+        const URI_TYPE(Uri) * absBase, UriBool domainRootMode) {
     return URI_FUNC(RemoveBaseUriMm)(dest, absSource, absBase, domainRootMode, NULL);
 }
 
 int URI_FUNC(RemoveBaseUriMm)(URI_TYPE(Uri) * dest, const URI_TYPE(Uri) * absSource,
-                              const URI_TYPE(Uri) * absBase, UriBool domainRootMode,
-                              UriMemoryManager * memory) {
+        const URI_TYPE(Uri) * absBase, UriBool domainRootMode,
+        UriMemoryManager * memory) {
     int res;
 
     URI_CHECK_MEMORY_MANAGER(memory); /* may return */

--- a/src/UriShorten.c
+++ b/src/UriShorten.c
@@ -71,7 +71,7 @@ static URI_INLINE UriBool URI_FUNC(AppendSegment)(URI_TYPE(Uri) * uri,
                                                   UriMemoryManager * memory) {
     /* Create segment */
     URI_TYPE(PathSegment) * segment =
-        memory->malloc(memory, 1 * sizeof(URI_TYPE(PathSegment)));
+            memory->malloc(memory, 1 * sizeof(URI_TYPE(PathSegment)));
     if (segment == NULL) {
         return URI_FALSE; /* Raises malloc error */
     }
@@ -96,16 +96,16 @@ static URI_INLINE UriBool URI_FUNC(EqualsAuthority)(const URI_TYPE(Uri) * first,
     if (first->hostData.ip4 != NULL) {
         return ((second->hostData.ip4 != NULL)
                 && !memcmp(first->hostData.ip4->data, second->hostData.ip4->data, 4))
-                   ? URI_TRUE
-                   : URI_FALSE;
+                       ? URI_TRUE
+                       : URI_FALSE;
     }
 
     /* IPv6 */
     if (first->hostData.ip6 != NULL) {
         return ((second->hostData.ip6 != NULL)
                 && !memcmp(first->hostData.ip6->data, second->hostData.ip6->data, 16))
-                   ? URI_TRUE
-                   : URI_FALSE;
+                       ? URI_TRUE
+                       : URI_FALSE;
     }
 
     /* IPvFuture */
@@ -113,8 +113,8 @@ static URI_INLINE UriBool URI_FUNC(EqualsAuthority)(const URI_TYPE(Uri) * first,
         return ((second->hostData.ipFuture.first != NULL)
                 && URI_FUNC(RangeEquals)(&first->hostData.ipFuture,
                                          &second->hostData.ipFuture))
-                   ? URI_TRUE
-                   : URI_FALSE;
+                       ? URI_TRUE
+                       : URI_FALSE;
     }
 
     return URI_FUNC(RangeEquals)(&first->hostText, &second->hostText) ? URI_TRUE
@@ -253,12 +253,13 @@ static int URI_FUNC(RemoveBaseUriImpl)(URI_TYPE(Uri) * dest,
                             /* clang-format off */
     /* [22/50]          while (first(A.path) == first(Base.path)) do */
                             /* clang-format on */
-                            while (
-                                (sourceSeg != NULL) && (baseSeg != NULL)
-                                && URI_FUNC(RangeEquals)(&sourceSeg->text, &baseSeg->text)
-                                && !((sourceSeg->text.first == sourceSeg->text.afterLast)
-                                     && ((sourceSeg->next == NULL)
-                                         != (baseSeg->next == NULL)))) {
+                            while ((sourceSeg != NULL) && (baseSeg != NULL)
+                                   && URI_FUNC(RangeEquals)(&sourceSeg->text,
+                                                            &baseSeg->text)
+                                   && !((sourceSeg->text.first
+                                         == sourceSeg->text.afterLast)
+                                        && ((sourceSeg->next == NULL)
+                                            != (baseSeg->next == NULL)))) {
                                 /* clang-format off */
     /* [23/50]             A.path++; */
                                 /* clang-format on */
@@ -320,8 +321,8 @@ static int URI_FUNC(RemoveBaseUriImpl)(URI_TYPE(Uri) * dest,
     /* [34/50]                   T.path += "./"; */
                                         /* clang-format on */
                                         if (!URI_FUNC(AppendSegment)(
-                                                dest, URI_FUNC(ConstPwd),
-                                                URI_FUNC(ConstPwd) + 1, memory)) {
+                                                    dest, URI_FUNC(ConstPwd),
+                                                    URI_FUNC(ConstPwd) + 1, memory)) {
                                             return URI_ERROR_MALLOC;
                                         }
                                         /* clang-format off */
@@ -333,8 +334,8 @@ static int URI_FUNC(RemoveBaseUriImpl)(URI_TYPE(Uri) * dest,
     /* [36/50]                   T.path += "/."; */
                                         /* clang-format on */
                                         if (!URI_FUNC(AppendSegment)(
-                                                dest, URI_FUNC(ConstPwd),
-                                                URI_FUNC(ConstPwd) + 1, memory)) {
+                                                    dest, URI_FUNC(ConstPwd),
+                                                    URI_FUNC(ConstPwd) + 1, memory)) {
                                             return URI_ERROR_MALLOC;
                                         }
                                         /* clang-format off */

--- a/test/CompareRangeLengthWrap.cpp
+++ b/test/CompareRangeLengthWrap.cpp
@@ -62,7 +62,7 @@ TEST(UriSuite, TestRangeComparisonDoesNotWrapLengthChecksOn64Bit) {
 
     // Reserve a huge virtual range, with access disabled by default.
     char * const hugeBase = static_cast<char *>(
-        mmap(NULL, hugeMapLen, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+            mmap(NULL, hugeMapLen, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
     ASSERT_NE(hugeBase, MAP_FAILED);
     // Allow access to the first page (and that only).
     ASSERT_EQ(0, mprotect(hugeBase, pageSize, PROT_READ | PROT_WRITE));
@@ -70,8 +70,9 @@ TEST(UriSuite, TestRangeComparisonDoesNotWrapLengthChecksOn64Bit) {
     // content comparison after truncating the large length.
     memset(hugeBase, 'a', pageSize);
 
-    char * const shortBase = static_cast<char *>(mmap(
-        NULL, shortMapLen, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    char * const shortBase =
+            static_cast<char *>(mmap(NULL, shortMapLen, PROT_READ | PROT_WRITE,
+                                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
     ASSERT_NE(shortBase, MAP_FAILED);
     // Guard the following page so any over-read beyond shortLen faults.
     ASSERT_EQ(0, mprotect(shortBase + pageSize, pageSize, PROT_NONE));

--- a/test/CompareRangeLengthWrap.cpp
+++ b/test/CompareRangeLengthWrap.cpp
@@ -70,9 +70,8 @@ TEST(UriSuite, TestRangeComparisonDoesNotWrapLengthChecksOn64Bit) {
     // content comparison after truncating the large length.
     memset(hugeBase, 'a', pageSize);
 
-    char * const shortBase =
-            static_cast<char *>(mmap(NULL, shortMapLen, PROT_READ | PROT_WRITE,
-                                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    char * const shortBase = static_cast<char *>(mmap(NULL, shortMapLen,
+            PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
     ASSERT_NE(shortBase, MAP_FAILED);
     // Guard the following page so any over-read beyond shortLen faults.
     ASSERT_EQ(0, mprotect(shortBase + pageSize, pageSize, PROT_NONE));

--- a/test/FourSuite.cpp
+++ b/test/FourSuite.cpp
@@ -134,7 +134,7 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper(";x", BASE_URI[0], "http://a/b/c/;x"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("g;x", BASE_URI[0], "http://a/b/c/g;x"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("g;x?y#s", BASE_URI[0], "http://a/b/c/g;x?y#s"));
+            testAddOrRemoveBaseHelper("g;x?y#s", BASE_URI[0], "http://a/b/c/g;x?y#s"));
 
     // changed with RFC 2396bis
     ASSERT_TRUE(testAddOrRemoveBaseHelper("", BASE_URI[0], "http://a/b/c/d;p?q"));
@@ -165,23 +165,23 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("g/./h", BASE_URI[0], "http://a/b/c/g/h"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("g/../h", BASE_URI[0], "http://a/b/c/h"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("g;x=1/./y", BASE_URI[0], "http://a/b/c/g;x=1/y"));
+            testAddOrRemoveBaseHelper("g;x=1/./y", BASE_URI[0], "http://a/b/c/g;x=1/y"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("g;x=1/../y", BASE_URI[0], "http://a/b/c/y"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("g?y/./x", BASE_URI[0], "http://a/b/c/g?y/./x"));
+            testAddOrRemoveBaseHelper("g?y/./x", BASE_URI[0], "http://a/b/c/g?y/./x"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("g?y/../x", BASE_URI[0], "http://a/b/c/g?y/../x"));
+            testAddOrRemoveBaseHelper("g?y/../x", BASE_URI[0], "http://a/b/c/g?y/../x"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("g#s/./x", BASE_URI[0], "http://a/b/c/g#s/./x"));
+            testAddOrRemoveBaseHelper("g#s/./x", BASE_URI[0], "http://a/b/c/g#s/./x"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("g#s/../x", BASE_URI[0], "http://a/b/c/g#s/../x"));
-    ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("http:g", BASE_URI[0], "http:g"));  // http://a/b/c/g
+            testAddOrRemoveBaseHelper("g#s/../x", BASE_URI[0], "http://a/b/c/g#s/../x"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("http:g", BASE_URI[0],
+                                          "http:g"));  // http://a/b/c/g
     ASSERT_TRUE(testAddOrRemoveBaseHelper("http:", BASE_URI[0], "http:"));  // BASE_URI[0]
 
     // not sure where this one originated
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("/a/b/c/./../../g", BASE_URI[0], "http://a/a/g"));
+            testAddOrRemoveBaseHelper("/a/b/c/./../../g", BASE_URI[0], "http://a/a/g"));
 
     // http://gbiv.com/protocols/uri/test/rel_examples2.html
     // slashes in base URI's query args
@@ -196,14 +196,14 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("?y", BASE_URI[1], "http://a/b/c/d;p?y"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("g?y", BASE_URI[1], "http://a/b/c/g?y"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("g?y/./x", BASE_URI[1], "http://a/b/c/g?y/./x"));
+            testAddOrRemoveBaseHelper("g?y/./x", BASE_URI[1], "http://a/b/c/g?y/./x"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("g?y/../x", BASE_URI[1], "http://a/b/c/g?y/../x"));
+            testAddOrRemoveBaseHelper("g?y/../x", BASE_URI[1], "http://a/b/c/g?y/../x"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("g#s", BASE_URI[1], "http://a/b/c/g#s"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("g#s/./x", BASE_URI[1], "http://a/b/c/g#s/./x"));
+            testAddOrRemoveBaseHelper("g#s/./x", BASE_URI[1], "http://a/b/c/g#s/./x"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("g#s/../x", BASE_URI[1], "http://a/b/c/g#s/../x"));
+            testAddOrRemoveBaseHelper("g#s/../x", BASE_URI[1], "http://a/b/c/g#s/../x"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("./", BASE_URI[1], "http://a/b/c/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../", BASE_URI[1], "http://a/b/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../g", BASE_URI[1], "http://a/b/g"));
@@ -222,7 +222,7 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("g;x=1/./y", BASE_URI[2],
                                           "http://a/b/c/d;p=1/g;x=1/y"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("g;x=1/../y", BASE_URI[2], "http://a/b/c/d;p=1/y"));
+            testAddOrRemoveBaseHelper("g;x=1/../y", BASE_URI[2], "http://a/b/c/d;p=1/y"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("./", BASE_URI[2], "http://a/b/c/d;p=1/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../", BASE_URI[2], "http://a/b/c/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../g", BASE_URI[2], "http://a/b/c/g"));
@@ -246,14 +246,15 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../", BASE_URI[3], "fred:///s//a/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../g", BASE_URI[3], "fred:///s//a/g"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper(
-        "../../", BASE_URI[3], "fred:///s//"));  // may change to fred:///s//a/../
+            "../../", BASE_URI[3], "fred:///s//"));  // may change to fred:///s//a/../
     ASSERT_TRUE(testAddOrRemoveBaseHelper(
-        "../../g", BASE_URI[3], "fred:///s//g"));  // may change to fred:///s//a/../g
+            "../../g", BASE_URI[3], "fred:///s//g"));  // may change to fred:///s//a/../g
     ASSERT_TRUE(testAddOrRemoveBaseHelper(
-        "../../../g", BASE_URI[3], "fred:///s/g"));  // may change to fred:///s//a/../../g
-    ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("../../../../g", BASE_URI[3],
-                                  "fred:///g"));  // may change to fred:///s//a/../../../g
+            "../../../g", BASE_URI[3],
+            "fred:///s/g"));  // may change to fred:///s//a/../../g
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "../../../../g", BASE_URI[3],
+            "fred:///g"));  // may change to fred:///s//a/../../../g
 
     // http://gbiv.com/protocols/uri/test/rel_examples5.html
     // double and triple slash, well-known scheme
@@ -272,14 +273,15 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../", BASE_URI[4], "http:///s//a/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../g", BASE_URI[4], "http:///s//a/g"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper(
-        "../../", BASE_URI[4], "http:///s//"));  // may change to http:///s//a/../
+            "../../", BASE_URI[4], "http:///s//"));  // may change to http:///s//a/../
     ASSERT_TRUE(testAddOrRemoveBaseHelper(
-        "../../g", BASE_URI[4], "http:///s//g"));  // may change to http:///s//a/../g
+            "../../g", BASE_URI[4], "http:///s//g"));  // may change to http:///s//a/../g
     ASSERT_TRUE(testAddOrRemoveBaseHelper(
-        "../../../g", BASE_URI[4], "http:///s/g"));  // may change to http:///s//a/../../g
-    ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("../../../../g", BASE_URI[4],
-                                  "http:///g"));  // may change to http:///s//a/../../../g
+            "../../../g", BASE_URI[4],
+            "http:///s/g"));  // may change to http:///s//a/../../g
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "../../../../g", BASE_URI[4],
+            "http:///g"));  // may change to http:///s//a/../../../g
 
     // from Dan Connelly's tests in http://www.w3.org/2000/10/swap/uripath.py
     ASSERT_TRUE(testAddOrRemoveBaseHelper("bar:abc", "foo:xyz", "bar:abc"));
@@ -291,9 +293,9 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("q/r", "http://ex/x/y", "http://ex/x/q/r"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("q/r#s", "http://ex/x/y", "http://ex/x/q/r#s"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("q/r#s/t", "http://ex/x/y", "http://ex/x/q/r#s/t"));
-    ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("ftp://ex/x/q/r", "http://ex/x/y", "ftp://ex/x/q/r"));
+            testAddOrRemoveBaseHelper("q/r#s/t", "http://ex/x/y", "http://ex/x/q/r#s/t"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("ftp://ex/x/q/r", "http://ex/x/y",
+                                          "ftp://ex/x/q/r"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("", "http://ex/x/y", "http://ex/x/y"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("", "http://ex/x/y/", "http://ex/x/y/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("", "http://ex/x/y/pdq", "http://ex/x/y/pdq"));
@@ -309,9 +311,9 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("q/r#s", "file:/ex/x/y", "file:/ex/x/q/r#s"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("q/r#", "file:/ex/x/y", "file:/ex/x/q/r#"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("q/r#s/t", "file:/ex/x/y", "file:/ex/x/q/r#s/t"));
-    ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("ftp://ex/x/q/r", "file:/ex/x/y", "ftp://ex/x/q/r"));
+            testAddOrRemoveBaseHelper("q/r#s/t", "file:/ex/x/y", "file:/ex/x/q/r#s/t"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("ftp://ex/x/q/r", "file:/ex/x/y",
+                                          "ftp://ex/x/q/r"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("", "file:/ex/x/y", "file:/ex/x/y"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("", "file:/ex/x/y/", "file:/ex/x/y/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("", "file:/ex/x/y/pdq", "file:/ex/x/y/pdq"));
@@ -320,17 +322,17 @@ TEST(FourSuite, AbsolutizeTestCases) {
                                           "file:/devel/WWW/2000/10/swap/test/reluri-1.n3",
                                           "file://meetings.example.com/cal#m1"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper(
-        "file://meetings.example.com/cal#m1",
-        "file:/home/connolly/w3ccvs/WWW/2000/10/swap/test/reluri-1.n3",
-        "file://meetings.example.com/cal#m1"));
+            "file://meetings.example.com/cal#m1",
+            "file:/home/connolly/w3ccvs/WWW/2000/10/swap/test/reluri-1.n3",
+            "file://meetings.example.com/cal#m1"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("./#blort", "file:/some/dir/foo",
                                           "file:/some/dir/#blort"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("./#", "file:/some/dir/foo", "file:/some/dir/#"));
+            testAddOrRemoveBaseHelper("./#", "file:/some/dir/foo", "file:/some/dir/#"));
 
     // Ryan Lee
-    ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("./", "http://example/x/abc.efg", "http://example/x/"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("./", "http://example/x/abc.efg",
+                                          "http://example/x/"));
 
     // Graham Klyne's tests
     // http://www.ninebynine.org/Software/HaskellUtils/Network/UriTest.xls
@@ -339,11 +341,11 @@ TEST(FourSuite, AbsolutizeTestCases) {
     // 32-49
     ASSERT_TRUE(testAddOrRemoveBaseHelper("./q:r", "http://ex/x/y", "http://ex/x/q:r"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("./p=q:r", "http://ex/x/y", "http://ex/x/p=q:r"));
+            testAddOrRemoveBaseHelper("./p=q:r", "http://ex/x/y", "http://ex/x/p=q:r"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("?pp/rr", "http://ex/x/y?pp/qq",
                                           "http://ex/x/y?pp/rr"));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("y/z", "http://ex/x/y?pp/qq", "http://ex/x/y/z"));
+            testAddOrRemoveBaseHelper("y/z", "http://ex/x/y?pp/qq", "http://ex/x/y/z"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("local/qual@domain.org#frag", "mailto:local",
                                           "mailto:local/qual@domain.org#frag"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("more/qual2@domain2.org#frag",
@@ -383,7 +385,7 @@ TEST(FourSuite, AbsolutizeTestCases) {
 
     // 70-77
     ASSERT_TRUE(testAddOrRemoveBaseHelper(
-        "local2@domain2", "mailto:local1@domain1?query1", "mailto:local2@domain2"));
+            "local2@domain2", "mailto:local1@domain1?query1", "mailto:local2@domain2"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("local2@domain2?query2",
                                           "mailto:local1@domain1",
                                           "mailto:local2@domain2?query2"));
@@ -412,11 +414,11 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("b/c//d/e", "f://example.org/base/a",
                                           "f://example.org/base/b/c//d/e"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper(
-        "m2@example.ord/c2@example.org", "mid:m@example.ord/c@example.org",
-        "mid:m@example.ord/m2@example.ord/c2@example.org"));
+            "m2@example.ord/c2@example.org", "mid:m@example.ord/c@example.org",
+            "mid:m@example.ord/m2@example.ord/c2@example.org"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper(
-        "mini1.xml", "file:///C:/DEV/Haskell/lib/HXmlToolbox-3.01/examples/",
-        "file:///C:/DEV/Haskell/lib/HXmlToolbox-3.01/examples/mini1.xml"));
+            "mini1.xml", "file:///C:/DEV/Haskell/lib/HXmlToolbox-3.01/examples/",
+            "file:///C:/DEV/Haskell/lib/HXmlToolbox-3.01/examples/mini1.xml"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../b/c", "foo:a/y/z", "foo:a/b/c"));
 }
 
@@ -427,11 +429,11 @@ TEST(FourSuite, RelativizeTestCases) {
     // to convert, base, expected
 
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("s://ex/a/b/c", "s://ex/a/d", "b/c", REMOVE_MODE));
+            testAddOrRemoveBaseHelper("s://ex/a/b/c", "s://ex/a/d", "b/c", REMOVE_MODE));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/b/b/c", "s://ex/a/d", "/b/b/c",
                                           REMOVE_MODE, DOMAIN_ROOT_MODE));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("s://ex/a/b/c", "s://ex/a/b/", "c", REMOVE_MODE));
+            testAddOrRemoveBaseHelper("s://ex/a/b/c", "s://ex/a/b/", "c", REMOVE_MODE));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("s://other.ex/a/b/", "s://ex/a/d",
                                           "//other.ex/a/b/", REMOVE_MODE));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c", "s://other.ex/a/d",
@@ -443,7 +445,7 @@ TEST(FourSuite, RelativizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a", "s://ex/b/c/d", "/a", REMOVE_MODE,
                                           DOMAIN_ROOT_MODE));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("s://ex/b/c/d", "s://ex/a", "b/c/d", REMOVE_MODE));
+            testAddOrRemoveBaseHelper("s://ex/b/c/d", "s://ex/a", "b/c/d", REMOVE_MODE));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c?h", "s://ex/a/d?w", "b/c?h",
                                           REMOVE_MODE));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c#h", "s://ex/a/d#w", "b/c#h",
@@ -457,8 +459,8 @@ TEST(FourSuite, RelativizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b", "s://ex/a/b", "", REMOVE_MODE));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/", "s://ex/", "", REMOVE_MODE));
 
-    ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("s://ex/a/b/c", "s://ex/a/d/c", "../b/c", REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c", "s://ex/a/d/c", "../b/c",
+                                          REMOVE_MODE));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c/", "s://ex/a/d/c", "../b/c/",
                                           REMOVE_MODE));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c/d", "s://ex/a/d/c/d",
@@ -469,14 +471,14 @@ TEST(FourSuite, RelativizeTestCases) {
                                           REMOVE_MODE));
 
     // Some tests to ensure that empty path segments don't cause problems.
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b", "s://ex/a//b/c", "../../b",
+                                          REMOVE_MODE));
     ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("s://ex/a/b", "s://ex/a//b/c", "../../b", REMOVE_MODE));
-    ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("s://ex/a///b", "s://ex/a/", ".///b", REMOVE_MODE));
-    ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("s://ex/a/", "s://ex/a///b", "../../", REMOVE_MODE));
-    ASSERT_TRUE(
-        testAddOrRemoveBaseHelper("s://ex/a//b/c", "s://ex/a/b", ".//b/c", REMOVE_MODE));
+            testAddOrRemoveBaseHelper("s://ex/a///b", "s://ex/a/", ".///b", REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/", "s://ex/a///b", "../../",
+                                          REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a//b/c", "s://ex/a/b", ".//b/c",
+                                          REMOVE_MODE));
 }
 
 namespace {
@@ -511,9 +513,9 @@ TEST(FourSuite, GoodUriReferences) {
     ASSERT_TRUE(testGoodUri("file:///foo/bar"));
     ASSERT_TRUE(testGoodUri("mailto:user@host?subject=blah"));
     ASSERT_TRUE(
-        testGoodUri("dav:"));  // empty opaque part / rel-path allowed by RFC 2396bis
-    ASSERT_TRUE(
-        testGoodUri("about:"));  // empty opaque part / rel-path allowed by RFC 2396bis
+            testGoodUri("dav:"));  // empty opaque part / rel-path allowed by RFC 2396bis
+    ASSERT_TRUE(testGoodUri(
+            "about:"));  // empty opaque part / rel-path allowed by RFC 2396bis
 
     // the following test cases are from a Perl script by David A. Wheeler
     // at http://www.dwheeler.com/secure-programs/url.pl
@@ -582,8 +584,8 @@ TEST(FourSuite, GoodUriReferences) {
     ASSERT_TRUE(testGoodUri("http://example.org"));
 
     // IPv6 literals (from RFC2732):
-    ASSERT_TRUE(
-        testGoodUri("http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/index.html"));
+    ASSERT_TRUE(testGoodUri(
+            "http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/index.html"));
     ASSERT_TRUE(testGoodUri("http://[1080:0:0:0:8:800:200C:417A]/index.html"));
     ASSERT_TRUE(testGoodUri("http://[3ffe:2a00:100:7031::1]"));
     ASSERT_TRUE(testGoodUri("http://[1080::8:800:200C:417A]/foo"));
@@ -601,7 +603,7 @@ TEST(FourSuite, BadUriReferences) {
     ASSERT_TRUE(testBadUri("beepbeep\x07\x07", 8));
     ASSERT_TRUE(testBadUri("\n", 0));
     ASSERT_TRUE(testBadUri(
-        "::", 0));  // not OK, per Roy Fielding on the W3C uri list on 2004-04-01
+            "::", 0));  // not OK, per Roy Fielding on the W3C uri list on 2004-04-01
 
     // the following test cases are from a Perl script by David A. Wheeler
     // at http://www.dwheeler.com/secure-programs/url.pl
@@ -682,16 +684,16 @@ bool normalizeAndCompare(const char * uriText, const char * expectedNormalized) 
 
 TEST(FourSuite, CaseNormalizationTests) {
     ASSERT_TRUE(
-        normalizeAndCompare("HTTP://www.EXAMPLE.com/", "http://www.example.com/"));
-    ASSERT_TRUE(
-        normalizeAndCompare("example://A/b/c/%7bfoo%7d", "example://a/b/c/%7Bfoo%7D"));
+            normalizeAndCompare("HTTP://www.EXAMPLE.com/", "http://www.example.com/"));
+    ASSERT_TRUE(normalizeAndCompare("example://A/b/c/%7bfoo%7d",
+                                    "example://a/b/c/%7Bfoo%7D"));
 }
 
 TEST(FourSuite, PctEncNormalizationTests) {
     ASSERT_TRUE(
-        normalizeAndCompare("http://host/%7Euser/x/y/z", "http://host/~user/x/y/z"));
+            normalizeAndCompare("http://host/%7Euser/x/y/z", "http://host/~user/x/y/z"));
     ASSERT_TRUE(
-        normalizeAndCompare("http://host/%7euser/x/y/z", "http://host/~user/x/y/z"));
+            normalizeAndCompare("http://host/%7euser/x/y/z", "http://host/~user/x/y/z"));
 }
 
 TEST(FourSuite, PathSegmentNormalizationTests) {

--- a/test/FourSuite.cpp
+++ b/test/FourSuite.cpp
@@ -29,7 +29,7 @@
 namespace {
 
 bool testAddOrRemoveBaseHelper(const char * ref, const char * base, const char * expected,
-                               bool add = true, bool domainRootMode = false) {
+        bool add = true, bool domainRootMode = false) {
     UriParserStateA stateA;
 
     // Base
@@ -66,7 +66,7 @@ bool testAddOrRemoveBaseHelper(const char * ref, const char * base, const char *
         res = uriAddBaseUriA(&transformedUri, &relUri, &baseUri);
     } else {
         res = uriRemoveBaseUriA(&transformedUri, &relUri, &baseUri,
-                                domainRootMode ? URI_TRUE : URI_FALSE);
+                domainRootMode ? URI_TRUE : URI_FALSE);
     }
     if (res != 0) {
         uriFreeUriMembersA(&baseUri);
@@ -83,7 +83,7 @@ bool testAddOrRemoveBaseHelper(const char * ref, const char * base, const char *
         uriToStringA(transformedUriText, &transformedUri, 1024 * 8, NULL);
         uriToStringA(expectedUriText, &expectedUri, 1024 * 8, NULL);
         printf("\n\n\nExpected: \"%s\"\nReceived: \"%s\"\n\n\n", expectedUriText,
-               transformedUriText);
+                transformedUriText);
     }
 
     uriFreeUriMembersA(&baseUri);
@@ -97,8 +97,7 @@ bool testAddOrRemoveBaseHelper(const char * ref, const char * base, const char *
 
 TEST(FourSuite, AbsolutizeTestCases) {
     const char * const BASE_URI[] = {"http://a/b/c/d;p?q", "http://a/b/c/d;p?q=1/2",
-                                     "http://a/b/c/d;p=1/2?q", "fred:///s//a/b/c",
-                                     "http:///s//a/b/c"};
+            "http://a/b/c/d;p=1/2?q", "fred:///s//a/b/c", "http:///s//a/b/c"};
 
     // ref, base, expected
 
@@ -147,9 +146,9 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../../", BASE_URI[0], "http://a/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../../g", BASE_URI[0], "http://a/g"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../../../g", BASE_URI[0],
-                                          "http://a/g"));  // http://a/../g
+            "http://a/g"));  // http://a/../g
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../../../../g", BASE_URI[0],
-                                          "http://a/g"));  // http://a/../../g
+            "http://a/g"));  // http://a/../../g
 
     // changed with RFC 2396bis
     ASSERT_TRUE(testAddOrRemoveBaseHelper("/./g", BASE_URI[0], "http://a/g"));
@@ -176,7 +175,7 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(
             testAddOrRemoveBaseHelper("g#s/../x", BASE_URI[0], "http://a/b/c/g#s/../x"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("http:g", BASE_URI[0],
-                                          "http:g"));  // http://a/b/c/g
+            "http:g"));  // http://a/b/c/g
     ASSERT_TRUE(testAddOrRemoveBaseHelper("http:", BASE_URI[0], "http:"));  // BASE_URI[0]
 
     // not sure where this one originated
@@ -219,8 +218,8 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("g?y", BASE_URI[2], "http://a/b/c/d;p=1/g?y"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper(";x", BASE_URI[2], "http://a/b/c/d;p=1/;x"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("g;x", BASE_URI[2], "http://a/b/c/d;p=1/g;x"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("g;x=1/./y", BASE_URI[2],
-                                          "http://a/b/c/d;p=1/g;x=1/y"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "g;x=1/./y", BASE_URI[2], "http://a/b/c/d;p=1/g;x=1/y"));
     ASSERT_TRUE(
             testAddOrRemoveBaseHelper("g;x=1/../y", BASE_URI[2], "http://a/b/c/d;p=1/y"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("./", BASE_URI[2], "http://a/b/c/d;p=1/"));
@@ -236,11 +235,11 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("./g", BASE_URI[3], "fred:///s//a/b/g"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("g/", BASE_URI[3], "fred:///s//a/b/g/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("/g", BASE_URI[3],
-                                          "fred:///g"));  // may change to fred:///s//a/g
+            "fred:///g"));  // may change to fred:///s//a/g
     ASSERT_TRUE(testAddOrRemoveBaseHelper("//g", BASE_URI[3],
-                                          "fred://g"));  // may change to fred:///s//g
+            "fred://g"));  // may change to fred:///s//g
     ASSERT_TRUE(testAddOrRemoveBaseHelper("//g/x", BASE_URI[3],
-                                          "fred://g/x"));  // may change to fred:///s//g/x
+            "fred://g/x"));  // may change to fred:///s//g/x
     ASSERT_TRUE(testAddOrRemoveBaseHelper("///g", BASE_URI[3], "fred:///g"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("./", BASE_URI[3], "fred:///s//a/b/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../", BASE_URI[3], "fred:///s//a/"));
@@ -249,11 +248,9 @@ TEST(FourSuite, AbsolutizeTestCases) {
             "../../", BASE_URI[3], "fred:///s//"));  // may change to fred:///s//a/../
     ASSERT_TRUE(testAddOrRemoveBaseHelper(
             "../../g", BASE_URI[3], "fred:///s//g"));  // may change to fred:///s//a/../g
-    ASSERT_TRUE(testAddOrRemoveBaseHelper(
-            "../../../g", BASE_URI[3],
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("../../../g", BASE_URI[3],
             "fred:///s/g"));  // may change to fred:///s//a/../../g
-    ASSERT_TRUE(testAddOrRemoveBaseHelper(
-            "../../../../g", BASE_URI[3],
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("../../../../g", BASE_URI[3],
             "fred:///g"));  // may change to fred:///s//a/../../../g
 
     // http://gbiv.com/protocols/uri/test/rel_examples5.html
@@ -263,11 +260,11 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("./g", BASE_URI[4], "http:///s//a/b/g"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("g/", BASE_URI[4], "http:///s//a/b/g/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("/g", BASE_URI[4],
-                                          "http:///g"));  // may change to http:///s//a/g
+            "http:///g"));  // may change to http:///s//a/g
     ASSERT_TRUE(testAddOrRemoveBaseHelper("//g", BASE_URI[4],
-                                          "http://g"));  // may change to http:///s//g
+            "http://g"));  // may change to http:///s//g
     ASSERT_TRUE(testAddOrRemoveBaseHelper("//g/x", BASE_URI[4],
-                                          "http://g/x"));  // may change to http:///s//g/x
+            "http://g/x"));  // may change to http:///s//g/x
     ASSERT_TRUE(testAddOrRemoveBaseHelper("///g", BASE_URI[4], "http:///g"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("./", BASE_URI[4], "http:///s//a/b/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../", BASE_URI[4], "http:///s//a/"));
@@ -276,35 +273,33 @@ TEST(FourSuite, AbsolutizeTestCases) {
             "../../", BASE_URI[4], "http:///s//"));  // may change to http:///s//a/../
     ASSERT_TRUE(testAddOrRemoveBaseHelper(
             "../../g", BASE_URI[4], "http:///s//g"));  // may change to http:///s//a/../g
-    ASSERT_TRUE(testAddOrRemoveBaseHelper(
-            "../../../g", BASE_URI[4],
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("../../../g", BASE_URI[4],
             "http:///s/g"));  // may change to http:///s//a/../../g
-    ASSERT_TRUE(testAddOrRemoveBaseHelper(
-            "../../../../g", BASE_URI[4],
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("../../../../g", BASE_URI[4],
             "http:///g"));  // may change to http:///s//a/../../../g
 
     // from Dan Connelly's tests in http://www.w3.org/2000/10/swap/uripath.py
     ASSERT_TRUE(testAddOrRemoveBaseHelper("bar:abc", "foo:xyz", "bar:abc"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("../abc", "http://example/x/y/z",
-                                          "http://example/x/abc"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("http://example/x/abc", "http://example2/x/y/z",
-                                          "http://example/x/abc"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "../abc", "http://example/x/y/z", "http://example/x/abc"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "http://example/x/abc", "http://example2/x/y/z", "http://example/x/abc"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../r", "http://ex/x/y/z", "http://ex/x/r"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("q/r", "http://ex/x/y", "http://ex/x/q/r"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("q/r#s", "http://ex/x/y", "http://ex/x/q/r#s"));
     ASSERT_TRUE(
             testAddOrRemoveBaseHelper("q/r#s/t", "http://ex/x/y", "http://ex/x/q/r#s/t"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("ftp://ex/x/q/r", "http://ex/x/y",
-                                          "ftp://ex/x/q/r"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "ftp://ex/x/q/r", "http://ex/x/y", "ftp://ex/x/q/r"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("", "http://ex/x/y", "http://ex/x/y"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("", "http://ex/x/y/", "http://ex/x/y/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("", "http://ex/x/y/pdq", "http://ex/x/y/pdq"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("z/", "http://ex/x/y/", "http://ex/x/y/z/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("#Animal", "file:/swap/test/animal.rdf",
-                                          "file:/swap/test/animal.rdf#Animal"));
+            "file:/swap/test/animal.rdf#Animal"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../abc", "file:/e/x/y/z", "file:/e/x/abc"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("/example/x/abc", "file:/example2/x/y/z",
-                                          "file:/example/x/abc"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "/example/x/abc", "file:/example2/x/y/z", "file:/example/x/abc"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../r", "file:/ex/x/y/z", "file:/ex/x/r"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("/r", "file:/ex/x/y/z", "file:/r"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("q/r", "file:/ex/x/y", "file:/ex/x/q/r"));
@@ -312,27 +307,26 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("q/r#", "file:/ex/x/y", "file:/ex/x/q/r#"));
     ASSERT_TRUE(
             testAddOrRemoveBaseHelper("q/r#s/t", "file:/ex/x/y", "file:/ex/x/q/r#s/t"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("ftp://ex/x/q/r", "file:/ex/x/y",
-                                          "ftp://ex/x/q/r"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "ftp://ex/x/q/r", "file:/ex/x/y", "ftp://ex/x/q/r"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("", "file:/ex/x/y", "file:/ex/x/y"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("", "file:/ex/x/y/", "file:/ex/x/y/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("", "file:/ex/x/y/pdq", "file:/ex/x/y/pdq"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("z/", "file:/ex/x/y/", "file:/ex/x/y/z/"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("file://meetings.example.com/cal#m1",
-                                          "file:/devel/WWW/2000/10/swap/test/reluri-1.n3",
-                                          "file://meetings.example.com/cal#m1"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper(
-            "file://meetings.example.com/cal#m1",
+            "file:/devel/WWW/2000/10/swap/test/reluri-1.n3",
+            "file://meetings.example.com/cal#m1"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("file://meetings.example.com/cal#m1",
             "file:/home/connolly/w3ccvs/WWW/2000/10/swap/test/reluri-1.n3",
             "file://meetings.example.com/cal#m1"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("./#blort", "file:/some/dir/foo",
-                                          "file:/some/dir/#blort"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "./#blort", "file:/some/dir/foo", "file:/some/dir/#blort"));
     ASSERT_TRUE(
             testAddOrRemoveBaseHelper("./#", "file:/some/dir/foo", "file:/some/dir/#"));
 
     // Ryan Lee
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("./", "http://example/x/abc.efg",
-                                          "http://example/x/"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "./", "http://example/x/abc.efg", "http://example/x/"));
 
     // Graham Klyne's tests
     // http://www.ninebynine.org/Software/HaskellUtils/Network/UriTest.xls
@@ -342,15 +336,15 @@ TEST(FourSuite, AbsolutizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("./q:r", "http://ex/x/y", "http://ex/x/q:r"));
     ASSERT_TRUE(
             testAddOrRemoveBaseHelper("./p=q:r", "http://ex/x/y", "http://ex/x/p=q:r"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("?pp/rr", "http://ex/x/y?pp/qq",
-                                          "http://ex/x/y?pp/rr"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "?pp/rr", "http://ex/x/y?pp/qq", "http://ex/x/y?pp/rr"));
     ASSERT_TRUE(
             testAddOrRemoveBaseHelper("y/z", "http://ex/x/y?pp/qq", "http://ex/x/y/z"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("local/qual@domain.org#frag", "mailto:local",
-                                          "mailto:local/qual@domain.org#frag"));
+            "mailto:local/qual@domain.org#frag"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("more/qual2@domain2.org#frag",
-                                          "mailto:local/qual1@domain1.org",
-                                          "mailto:local/more/qual2@domain2.org#frag"));
+            "mailto:local/qual1@domain1.org",
+            "mailto:local/more/qual2@domain2.org#frag"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("y?q", "http://ex/x/y?q", "http://ex/x/y?q"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("/x/y?q", "http://ex?p", "http://ex/x/y?q"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("c/d", "foo:a/b", "foo:a/c/d"));
@@ -367,57 +361,55 @@ TEST(FourSuite, AbsolutizeTestCases) {
     // 50-57 (cf. TimBL comments --
     // http://lists.w3.org/Archives/Public/uri/2003Feb/0028.html,
     // http://lists.w3.org/Archives/Public/uri/2003Jan/0008.html)
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("abc", "http://example/x/y%2Fz",
-                                          "http://example/x/abc"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("../../x%2Fabc", "http://example/a/x/y/z",
-                                          "http://example/a/x%2Fabc"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("../x%2Fabc", "http://example/a/x/y%2Fz",
-                                          "http://example/a/x%2Fabc"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("abc", "http://example/x%2Fy/z",
-                                          "http://example/x%2Fy/abc"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "abc", "http://example/x/y%2Fz", "http://example/x/abc"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "../../x%2Fabc", "http://example/a/x/y/z", "http://example/a/x%2Fabc"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "../x%2Fabc", "http://example/a/x/y%2Fz", "http://example/a/x%2Fabc"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "abc", "http://example/x%2Fy/z", "http://example/x%2Fy/abc"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("q%3Ar", "http://ex/x/y", "http://ex/x/q%3Ar"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("/x%2Fabc", "http://example/x/y%2Fz",
-                                          "http://example/x%2Fabc"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("/x%2Fabc", "http://example/x/y/z",
-                                          "http://example/x%2Fabc"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("/x%2Fabc", "http://example/x/y%2Fz",
-                                          "http://example/x%2Fabc"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "/x%2Fabc", "http://example/x/y%2Fz", "http://example/x%2Fabc"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "/x%2Fabc", "http://example/x/y/z", "http://example/x%2Fabc"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "/x%2Fabc", "http://example/x/y%2Fz", "http://example/x%2Fabc"));
 
     // 70-77
     ASSERT_TRUE(testAddOrRemoveBaseHelper(
             "local2@domain2", "mailto:local1@domain1?query1", "mailto:local2@domain2"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("local2@domain2?query2",
-                                          "mailto:local1@domain1",
-                                          "mailto:local2@domain2?query2"));
+            "mailto:local1@domain1", "mailto:local2@domain2?query2"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("local2@domain2?query2",
-                                          "mailto:local1@domain1?query1",
-                                          "mailto:local2@domain2?query2"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("?query2", "mailto:local@domain?query1",
-                                          "mailto:local@domain?query2"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("local@domain?query2", "mailto:?query1",
-                                          "mailto:local@domain?query2"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("?query2", "mailto:local@domain?query1",
-                                          "mailto:local@domain?query2"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("http://example/a/b?c/../d", "foo:bar",
-                                          "http://example/a/b?c/../d"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("http://example/a/b#c/../d", "foo:bar",
-                                          "http://example/a/b#c/../d"));
+            "mailto:local1@domain1?query1", "mailto:local2@domain2?query2"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "?query2", "mailto:local@domain?query1", "mailto:local@domain?query2"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "local@domain?query2", "mailto:?query1", "mailto:local@domain?query2"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "?query2", "mailto:local@domain?query1", "mailto:local@domain?query2"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "http://example/a/b?c/../d", "foo:bar", "http://example/a/b?c/../d"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "http://example/a/b#c/../d", "foo:bar", "http://example/a/b#c/../d"));
 
     // 82-88
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("http:this", "http://example.org/base/uri",
-                                          "http:this"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "http:this", "http://example.org/base/uri", "http:this"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("http:this", "http:base", "http:this"));
     // Whole in the URI spec, see
     // http://lists.w3.org/Archives/Public/uri/2007Aug/0003.html
     // ASSERT_TRUE(testAddOrRemoveBaseHelper(".//g", "f:/a", "f://g")); // ORIGINAL
     ASSERT_TRUE(testAddOrRemoveBaseHelper(".//g", "f:/a", "f:/.//g"));  // FIXED ONE
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("b/c//d/e", "f://example.org/base/a",
-                                          "f://example.org/base/b/c//d/e"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper(
-            "m2@example.ord/c2@example.org", "mid:m@example.ord/c@example.org",
+            "b/c//d/e", "f://example.org/base/a", "f://example.org/base/b/c//d/e"));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("m2@example.ord/c2@example.org",
+            "mid:m@example.ord/c@example.org",
             "mid:m@example.ord/m2@example.ord/c2@example.org"));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper(
-            "mini1.xml", "file:///C:/DEV/Haskell/lib/HXmlToolbox-3.01/examples/",
+    ASSERT_TRUE(testAddOrRemoveBaseHelper("mini1.xml",
+            "file:///C:/DEV/Haskell/lib/HXmlToolbox-3.01/examples/",
             "file:///C:/DEV/Haskell/lib/HXmlToolbox-3.01/examples/mini1.xml"));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("../b/c", "foo:a/y/z", "foo:a/b/c"));
 }
@@ -430,28 +422,28 @@ TEST(FourSuite, RelativizeTestCases) {
 
     ASSERT_TRUE(
             testAddOrRemoveBaseHelper("s://ex/a/b/c", "s://ex/a/d", "b/c", REMOVE_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/b/b/c", "s://ex/a/d", "/b/b/c",
-                                          REMOVE_MODE, DOMAIN_ROOT_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/b/b/c", "s://ex/a/d", "/b/b/c", REMOVE_MODE, DOMAIN_ROOT_MODE));
     ASSERT_TRUE(
             testAddOrRemoveBaseHelper("s://ex/a/b/c", "s://ex/a/b/", "c", REMOVE_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://other.ex/a/b/", "s://ex/a/d",
-                                          "//other.ex/a/b/", REMOVE_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c", "s://other.ex/a/d",
-                                          "//ex/a/b/c", REMOVE_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("t://ex/a/b/c", "s://ex/a/d", "t://ex/a/b/c",
-                                          REMOVE_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c", "t://ex/a/d", "s://ex/a/b/c",
-                                          REMOVE_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a", "s://ex/b/c/d", "/a", REMOVE_MODE,
-                                          DOMAIN_ROOT_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://other.ex/a/b/", "s://ex/a/d", "//other.ex/a/b/", REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/a/b/c", "s://other.ex/a/d", "//ex/a/b/c", REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "t://ex/a/b/c", "s://ex/a/d", "t://ex/a/b/c", REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/a/b/c", "t://ex/a/d", "s://ex/a/b/c", REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/a", "s://ex/b/c/d", "/a", REMOVE_MODE, DOMAIN_ROOT_MODE));
     ASSERT_TRUE(
             testAddOrRemoveBaseHelper("s://ex/b/c/d", "s://ex/a", "b/c/d", REMOVE_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c?h", "s://ex/a/d?w", "b/c?h",
-                                          REMOVE_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c#h", "s://ex/a/d#w", "b/c#h",
-                                          REMOVE_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c?h#i", "s://ex/a/d?w#j", "b/c?h#i",
-                                          REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/a/b/c?h", "s://ex/a/d?w", "b/c?h", REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/a/b/c#h", "s://ex/a/d#w", "b/c#h", REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/a/b/c?h#i", "s://ex/a/d?w#j", "b/c?h#i", REMOVE_MODE));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a#i", "s://ex/a", "#i", REMOVE_MODE));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a?i", "s://ex/a", "?i", REMOVE_MODE));
 
@@ -459,26 +451,26 @@ TEST(FourSuite, RelativizeTestCases) {
     ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b", "s://ex/a/b", "", REMOVE_MODE));
     ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/", "s://ex/", "", REMOVE_MODE));
 
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c", "s://ex/a/d/c", "../b/c",
-                                          REMOVE_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c/", "s://ex/a/d/c", "../b/c/",
-                                          REMOVE_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c/d", "s://ex/a/d/c/d",
-                                          "../../b/c/d", REMOVE_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/c", "s://ex/d/e/f", "/a/b/c",
-                                          REMOVE_MODE, DOMAIN_ROOT_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b/", "s://ex/a/c/d/e", "../../b/",
-                                          REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/a/b/c", "s://ex/a/d/c", "../b/c", REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/a/b/c/", "s://ex/a/d/c", "../b/c/", REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/a/b/c/d", "s://ex/a/d/c/d", "../../b/c/d", REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/a/b/c", "s://ex/d/e/f", "/a/b/c", REMOVE_MODE, DOMAIN_ROOT_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/a/b/", "s://ex/a/c/d/e", "../../b/", REMOVE_MODE));
 
     // Some tests to ensure that empty path segments don't cause problems.
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/b", "s://ex/a//b/c", "../../b",
-                                          REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/a/b", "s://ex/a//b/c", "../../b", REMOVE_MODE));
     ASSERT_TRUE(
             testAddOrRemoveBaseHelper("s://ex/a///b", "s://ex/a/", ".///b", REMOVE_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a/", "s://ex/a///b", "../../",
-                                          REMOVE_MODE));
-    ASSERT_TRUE(testAddOrRemoveBaseHelper("s://ex/a//b/c", "s://ex/a/b", ".//b/c",
-                                          REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/a/", "s://ex/a///b", "../../", REMOVE_MODE));
+    ASSERT_TRUE(testAddOrRemoveBaseHelper(
+            "s://ex/a//b/c", "s://ex/a/b", ".//b/c", REMOVE_MODE));
 }
 
 namespace {
@@ -504,7 +496,7 @@ bool testBadUri(const char * uriText, int expectedErrorOffset = -1) {
     const int ret = testParseUri(uriText, &errorPos);
     return ((ret == URI_ERROR_SYNTAX) && (errorPos != NULL)
             && ((expectedErrorOffset == -1)
-                || (errorPos == (uriText + expectedErrorOffset))));
+                    || (errorPos == (uriText + expectedErrorOffset))));
 }
 
 }  // namespace
@@ -685,8 +677,8 @@ bool normalizeAndCompare(const char * uriText, const char * expectedNormalized) 
 TEST(FourSuite, CaseNormalizationTests) {
     ASSERT_TRUE(
             normalizeAndCompare("HTTP://www.EXAMPLE.com/", "http://www.example.com/"));
-    ASSERT_TRUE(normalizeAndCompare("example://A/b/c/%7bfoo%7d",
-                                    "example://a/b/c/%7Bfoo%7D"));
+    ASSERT_TRUE(normalizeAndCompare(
+            "example://A/b/c/%7bfoo%7d", "example://a/b/c/%7Bfoo%7D"));
 }
 
 TEST(FourSuite, PctEncNormalizationTests) {

--- a/test/MemoryManagerSuite.cpp
+++ b/test/MemoryManagerSuite.cpp
@@ -38,8 +38,8 @@ namespace {
 static void * failingMalloc(UriMemoryManager * memory, size_t size);
 static void * failingCalloc(UriMemoryManager * memory, size_t nmemb, size_t size);
 static void * failingRealloc(UriMemoryManager * memory, void * ptr, size_t size);
-static void * failingReallocarray(UriMemoryManager * memory, void * ptr, size_t nmemb,
-                                  size_t size);
+static void * failingReallocarray(
+        UriMemoryManager * memory, void * ptr, size_t nmemb, size_t size);
 static void countingFree(UriMemoryManager * memory, void * ptr);
 
 class FailingMemoryManager {
@@ -52,8 +52,8 @@ private:
     friend void * failingMalloc(UriMemoryManager * memory, size_t size);
     friend void * failingCalloc(UriMemoryManager * memory, size_t nmemb, size_t size);
     friend void * failingRealloc(UriMemoryManager * memory, void * ptr, size_t size);
-    friend void * failingReallocarray(UriMemoryManager * memory, void * ptr, size_t nmemb,
-                                      size_t size);
+    friend void * failingReallocarray(
+            UriMemoryManager * memory, void * ptr, size_t nmemb, size_t size);
     friend void countingFree(UriMemoryManager * memory, void * ptr);
 
 public:
@@ -113,8 +113,8 @@ static void * failingRealloc(UriMemoryManager * memory, void * ptr, size_t size)
     return realloc(ptr, size);
 }
 
-static void * failingReallocarray(UriMemoryManager * memory, void * ptr, size_t nmemb,
-                                  size_t size) {
+static void * failingReallocarray(
+        UriMemoryManager * memory, void * ptr, size_t nmemb, size_t size) {
     return uriEmulateReallocarray(memory, ptr, nmemb, size);
 }
 
@@ -178,12 +178,12 @@ TEST(MemoryManagerCompletionSuite, MallocAndFreeRequired) {
     memcpy(&backend, &defaultMemoryManager, sizeof(UriMemoryManager));
     backend.malloc = NULL;
     ASSERT_EQ(uriCompleteMemoryManager(&memory, &backend),
-              URI_ERROR_MEMORY_MANAGER_INCOMPLETE);
+            URI_ERROR_MEMORY_MANAGER_INCOMPLETE);
 
     memcpy(&backend, &defaultMemoryManager, sizeof(UriMemoryManager));
     backend.free = NULL;
     ASSERT_EQ(uriCompleteMemoryManager(&memory, &backend),
-              URI_ERROR_MEMORY_MANAGER_INCOMPLETE);
+            URI_ERROR_MEMORY_MANAGER_INCOMPLETE);
 }
 
 TEST(MemoryManagerTestingSuite, DefaultMemoryManager) {
@@ -206,21 +206,21 @@ TEST(MemoryManagerCompletionSuite, MallocAndFreeSufficient) {
 TEST(MemoryManagerTestingSuite, EmulateCalloc) {
     UriMemoryManager partialEmulationMemoryManager;
     memcpy(&partialEmulationMemoryManager, &defaultMemoryManager,
-           sizeof(UriMemoryManager));
+            sizeof(UriMemoryManager));
     partialEmulationMemoryManager.calloc = uriEmulateCalloc;
 
     ASSERT_EQ(uriTestMemoryManagerEx(&partialEmulationMemoryManager, URI_TRUE),
-              URI_SUCCESS);
+            URI_SUCCESS);
 }
 
 TEST(MemoryManagerTestingSuite, EmulateReallocarray) {
     UriMemoryManager partialEmulationMemoryManager;
     memcpy(&partialEmulationMemoryManager, &defaultMemoryManager,
-           sizeof(UriMemoryManager));
+            sizeof(UriMemoryManager));
     partialEmulationMemoryManager.reallocarray = uriEmulateReallocarray;
 
     ASSERT_EQ(uriTestMemoryManagerEx(&partialEmulationMemoryManager, URI_TRUE),
-              URI_SUCCESS);
+            URI_SUCCESS);
 }
 
 TEST(MemoryManagerTestingOverflowDetectionSuite, EmulateCalloc) {
@@ -235,20 +235,20 @@ TEST(MemoryManagerTestingOverflowDetectionSuite, EmulateReallocarray) {
     EXPECT_GT(2 * sizeof(size_t), sizeof(void *));
 
     errno = 0;
-    ASSERT_EQ(NULL, uriEmulateReallocarray(&defaultMemoryManager, NULL, (size_t)-1,
-                                           (size_t)-1));
+    ASSERT_EQ(NULL,
+            uriEmulateReallocarray(&defaultMemoryManager, NULL, (size_t)-1, (size_t)-1));
     ASSERT_EQ(errno, ENOMEM);
 }
 
 TEST(MemoryManagerTestingSuite, EmulateCallocAndReallocarray) {
     UriMemoryManager partialEmulationMemoryManager;
     memcpy(&partialEmulationMemoryManager, &defaultMemoryManager,
-           sizeof(UriMemoryManager));
+            sizeof(UriMemoryManager));
     partialEmulationMemoryManager.calloc = uriEmulateCalloc;
     partialEmulationMemoryManager.reallocarray = uriEmulateReallocarray;
 
     ASSERT_EQ(uriTestMemoryManagerEx(&partialEmulationMemoryManager, URI_TRUE),
-              URI_SUCCESS);
+            URI_SUCCESS);
 }
 
 TEST(FailingMemoryManagerSuite, AddBaseUriExMm) {
@@ -259,8 +259,8 @@ TEST(FailingMemoryManagerSuite, AddBaseUriExMm) {
     FailingMemoryManager failingMemoryManager;
 
     ASSERT_EQ(uriAddBaseUriExMmA(&absoluteDest, &relativeSource, &absoluteBase, options,
-                                 &failingMemoryManager),
-              URI_ERROR_MALLOC);
+                      &failingMemoryManager),
+            URI_ERROR_MALLOC);
 
     uriFreeUriMembersA(&relativeSource);
     uriFreeUriMembersA(&absoluteBase);
@@ -274,8 +274,8 @@ TEST(FailingMemoryManagerSuite, ComposeQueryMallocExMm) {
     FailingMemoryManager failingMemoryManager;
 
     ASSERT_EQ(uriComposeQueryMallocExMmA(&dest, queryList, spaceToPlus, normalizeBreaks,
-                                         &failingMemoryManager),
-              URI_ERROR_MALLOC);
+                      &failingMemoryManager),
+            URI_ERROR_MALLOC);
 
     uriFreeQueryListA(queryList);
 }
@@ -290,9 +290,8 @@ TEST(FailingMemoryManagerSuite, DissectQueryMallocExMm) {
     FailingMemoryManager failingMemoryManager;
 
     ASSERT_EQ(uriDissectQueryMallocExMmA(&queryList, &itemCount, first, afterLast,
-                                         plusToSpace, breakConversion,
-                                         &failingMemoryManager),
-              URI_ERROR_MALLOC);
+                      plusToSpace, breakConversion, &failingMemoryManager),
+            URI_ERROR_MALLOC);
 }
 
 TEST(FailingMemoryManagerSuite, FreeQueryListMm) {
@@ -323,7 +322,7 @@ TEST(FailingMemoryManagerSuite, IsWellFormedHostIp6Mm) {
     EXPECT_EQ(failingMemoryManager.getCallCountAlloc(), 0U);
 
     EXPECT_EQ(uriIsWellFormedHostIp6MmA(first, afterLast, &failingMemoryManager),
-              URI_ERROR_MALLOC);
+            URI_ERROR_MALLOC);
 
     EXPECT_EQ(failingMemoryManager.getCallCountAlloc(), 1U);
 }
@@ -335,7 +334,7 @@ TEST(FailingMemoryManagerSuite, IsWellFormedHostIpFutureMm) {
     EXPECT_EQ(failingMemoryManager.getCallCountAlloc(), 0U);
 
     EXPECT_EQ(uriIsWellFormedHostIpFutureMmA(first, afterLast, &failingMemoryManager),
-              URI_ERROR_MALLOC);
+            URI_ERROR_MALLOC);
 
     EXPECT_EQ(failingMemoryManager.getCallCountAlloc(), 1U);
 }
@@ -348,7 +347,7 @@ TEST(FailingMemoryManagerSuite, SetPortTextMm) {
     ASSERT_EQ(failingMemoryManager.getCallCountAlloc(), 0U);
 
     ASSERT_EQ(uriSetPortTextMmA(&uri, first, afterLast, &failingMemoryManager),
-              URI_ERROR_MALLOC);
+            URI_ERROR_MALLOC);
 
     ASSERT_EQ(failingMemoryManager.getCallCountAlloc(), 1U);
 
@@ -363,7 +362,7 @@ TEST(FailingMemoryManagerSuite, SetQueryMm) {
     ASSERT_EQ(failingMemoryManager.getCallCountAlloc(), 0U);
 
     ASSERT_EQ(uriSetQueryMmA(&uri, first, afterLast, &failingMemoryManager),
-              URI_ERROR_MALLOC);
+            URI_ERROR_MALLOC);
 
     ASSERT_EQ(failingMemoryManager.getCallCountAlloc(), 1U);
 
@@ -378,7 +377,7 @@ TEST(FailingMemoryManagerSuite, SetUserInfoMm) {
     ASSERT_EQ(failingMemoryManager.getCallCountAlloc(), 0U);
 
     ASSERT_EQ(uriSetUserInfoMmA(&uri, first, afterLast, &failingMemoryManager),
-              URI_ERROR_MALLOC);
+            URI_ERROR_MALLOC);
 
     ASSERT_EQ(failingMemoryManager.getCallCountAlloc(), 1U);
 
@@ -386,14 +385,14 @@ TEST(FailingMemoryManagerSuite, SetUserInfoMm) {
 }
 
 namespace {
-void testNormalizeSyntaxWithFailingMallocCallsFreeTimes(
-        const char * uriString, unsigned int mask, unsigned int failAllocAfterTimes = 0,
+void testNormalizeSyntaxWithFailingMallocCallsFreeTimes(const char * uriString,
+        unsigned int mask, unsigned int failAllocAfterTimes = 0,
         unsigned int expectedCallCountFree = 0) {
     UriUriA uri = parse(uriString);
     FailingMemoryManager failingMemoryManager(failAllocAfterTimes);
 
-    ASSERT_EQ(uriNormalizeSyntaxExMmA(&uri, mask, &failingMemoryManager),
-              URI_ERROR_MALLOC);
+    ASSERT_EQ(
+            uriNormalizeSyntaxExMmA(&uri, mask, &failingMemoryManager), URI_ERROR_MALLOC);
 
     EXPECT_EQ(failingMemoryManager.getCallCountFree(), expectedCallCountFree);
 
@@ -402,13 +401,13 @@ void testNormalizeSyntaxWithFailingMallocCallsFreeTimes(
 }  // namespace
 
 TEST(FailingMemoryManagerSuite, NormalizeSyntaxExMmScheme) {
-    testNormalizeSyntaxWithFailingMallocCallsFreeTimes("hTTp://example.org/path",
-                                                       URI_NORMALIZE_SCHEME);
+    testNormalizeSyntaxWithFailingMallocCallsFreeTimes(
+            "hTTp://example.org/path", URI_NORMALIZE_SCHEME);
 }
 
 TEST(FailingMemoryManagerSuite, NormalizeSyntaxExMmEmptyUserInfo) {
-    testNormalizeSyntaxWithFailingMallocCallsFreeTimes("//@:123",
-                                                       URI_NORMALIZE_USER_INFO);
+    testNormalizeSyntaxWithFailingMallocCallsFreeTimes(
+            "//@:123", URI_NORMALIZE_USER_INFO);
 }
 
 TEST(FailingMemoryManagerSuite, NormalizeSyntaxExMmEmptyHostRegname) {
@@ -424,8 +423,8 @@ TEST(FailingMemoryManagerSuite, NormalizeSyntaxExMmEmptyFragment) {
 }
 
 TEST(FailingMemoryManagerSuite, NormalizeSyntaxExMmHostTextIp4) {  // issue #121
-    testNormalizeSyntaxWithFailingMallocCallsFreeTimes("//192.0.2.0:123" /* RFC 5737 */,
-                                                       URI_NORMALIZE_HOST, 1, 1);
+    testNormalizeSyntaxWithFailingMallocCallsFreeTimes(
+            "//192.0.2.0:123" /* RFC 5737 */, URI_NORMALIZE_HOST, 1, 1);
 }
 
 TEST(FailingMemoryManagerSuite, NormalizeSyntaxExMmHostTextIp6) {  // issue #121
@@ -450,7 +449,7 @@ TEST(FailingMemoryManagerSuite, ParseSingleUriExMm) {
     FailingMemoryManager failingMemoryManager;
 
     ASSERT_EQ(uriParseSingleUriExMmA(&uri, first, afterLast, NULL, &failingMemoryManager),
-              URI_ERROR_MALLOC);
+            URI_ERROR_MALLOC);
 }
 
 TEST(FailingMemoryManagerSuite, RemoveBaseUriMm) {
@@ -461,8 +460,8 @@ TEST(FailingMemoryManagerSuite, RemoveBaseUriMm) {
     FailingMemoryManager failingMemoryManager;
 
     ASSERT_EQ(uriRemoveBaseUriMmA(&dest, &absoluteSource, &absoluteBase, domainRootMode,
-                                  &failingMemoryManager),
-              URI_ERROR_MALLOC);
+                      &failingMemoryManager),
+            URI_ERROR_MALLOC);
 
     uriFreeUriMembersA(&absoluteSource);
     uriFreeUriMembersA(&absoluteBase);

--- a/test/MemoryManagerSuite.cpp
+++ b/test/MemoryManagerSuite.cpp
@@ -82,7 +82,7 @@ public:
 
 static void * failingMalloc(UriMemoryManager * memory, size_t size) {
     FailingMemoryManager * const fmm =
-        static_cast<FailingMemoryManager *>(memory->userData);
+            static_cast<FailingMemoryManager *>(memory->userData);
     fmm->callCountAlloc++;
     if (fmm->callCountAlloc > fmm->failAllocAfterTimes) {
         errno = ENOMEM;
@@ -93,7 +93,7 @@ static void * failingMalloc(UriMemoryManager * memory, size_t size) {
 
 static void * failingCalloc(UriMemoryManager * memory, size_t nmemb, size_t size) {
     FailingMemoryManager * const fmm =
-        static_cast<FailingMemoryManager *>(memory->userData);
+            static_cast<FailingMemoryManager *>(memory->userData);
     fmm->callCountAlloc++;
     if (fmm->callCountAlloc > fmm->failAllocAfterTimes) {
         errno = ENOMEM;
@@ -104,7 +104,7 @@ static void * failingCalloc(UriMemoryManager * memory, size_t nmemb, size_t size
 
 static void * failingRealloc(UriMemoryManager * memory, void * ptr, size_t size) {
     FailingMemoryManager * const fmm =
-        static_cast<FailingMemoryManager *>(memory->userData);
+            static_cast<FailingMemoryManager *>(memory->userData);
     fmm->callCountAlloc++;
     if (fmm->callCountAlloc > fmm->failAllocAfterTimes) {
         errno = ENOMEM;
@@ -120,7 +120,7 @@ static void * failingReallocarray(UriMemoryManager * memory, void * ptr, size_t 
 
 static void countingFree(UriMemoryManager * memory, void * ptr) {
     FailingMemoryManager * const fmm =
-        static_cast<FailingMemoryManager *>(memory->userData);
+            static_cast<FailingMemoryManager *>(memory->userData);
     fmm->callCountFree++;
     return free(ptr);
 }
@@ -387,8 +387,8 @@ TEST(FailingMemoryManagerSuite, SetUserInfoMm) {
 
 namespace {
 void testNormalizeSyntaxWithFailingMallocCallsFreeTimes(
-    const char * uriString, unsigned int mask, unsigned int failAllocAfterTimes = 0,
-    unsigned int expectedCallCountFree = 0) {
+        const char * uriString, unsigned int mask, unsigned int failAllocAfterTimes = 0,
+        unsigned int expectedCallCountFree = 0) {
     UriUriA uri = parse(uriString);
     FailingMemoryManager failingMemoryManager(failAllocAfterTimes);
 
@@ -430,17 +430,17 @@ TEST(FailingMemoryManagerSuite, NormalizeSyntaxExMmHostTextIp4) {  // issue #121
 
 TEST(FailingMemoryManagerSuite, NormalizeSyntaxExMmHostTextIp6) {  // issue #121
     testNormalizeSyntaxWithFailingMallocCallsFreeTimes(
-        "//[2001:db8::]:123" /* RFC 3849 */, URI_NORMALIZE_HOST, 1, 1);
+            "//[2001:db8::]:123" /* RFC 3849 */, URI_NORMALIZE_HOST, 1, 1);
 }
 
 TEST(FailingMemoryManagerSuite, NormalizeSyntaxExMmHostTextRegname) {  // issue #121
     testNormalizeSyntaxWithFailingMallocCallsFreeTimes(
-        "//host123.test:123" /* RFC 6761 */, URI_NORMALIZE_HOST, 1, 1);
+            "//host123.test:123" /* RFC 6761 */, URI_NORMALIZE_HOST, 1, 1);
 }
 
 TEST(FailingMemoryManagerSuite, NormalizeSyntaxExMmHostTextFuture) {  // issue #121
     testNormalizeSyntaxWithFailingMallocCallsFreeTimes(
-        "//[v7.X]:123" /* arbitrary IPvFuture */, URI_NORMALIZE_HOST, 1, 1);
+            "//[v7.X]:123" /* arbitrary IPvFuture */, URI_NORMALIZE_HOST, 1, 1);
 }
 
 TEST(FailingMemoryManagerSuite, ParseSingleUriExMm) {

--- a/test/SetFragment.cpp
+++ b/test/SetFragment.cpp
@@ -31,7 +31,7 @@ namespace {
 static void testIsWellFormedFragment(const char * candidate, bool expectedWellFormed) {
     const char * const first = candidate;
     const char * const afterLast =
-        (candidate == NULL) ? NULL : (candidate + strlen(candidate));
+            (candidate == NULL) ? NULL : (candidate + strlen(candidate));
 
     const UriBool actualWellFormed = uriIsWellFormedFragmentA(first, afterLast);
 

--- a/test/SetFragment.cpp
+++ b/test/SetFragment.cpp
@@ -90,7 +90,7 @@ TEST(IsWellFormedFragment, AllowedCharacters) {
                              "!$&'()*+,;="
                              ":@"
                              "/?",
-                             true);
+            true);
 }
 
 TEST(IsWellFormedFragment, ForbiddenCharacters) {
@@ -102,7 +102,7 @@ TEST(IsWellFormedFragment, PercentEncodingWellFormed) {
                              "aa"
                              "%"
                              "AA",
-                             true);
+            true);
 }
 
 TEST(IsWellFormedFragment, PercentEncodingMalformedCutOff1) {
@@ -112,19 +112,19 @@ TEST(IsWellFormedFragment, PercentEncodingMalformedCutOff1) {
 TEST(IsWellFormedFragment, PercentEncodingMalformedCutOff2) {
     testIsWellFormedFragment("%"
                              "a",
-                             false);
+            false);
 }
 
 TEST(IsWellFormedFragment, PercentEncodingMalformedForbiddenCharacter1) {
     testIsWellFormedFragment("%"
                              "ga",
-                             false);
+            false);
 }
 
 TEST(IsWellFormedFragment, PercentEncodingMalformedForbiddenCharacter2) {
     testIsWellFormedFragment("%"
                              "ag",
-                             false);
+            false);
 }
 
 TEST(SetFragment, NullUriOnly) {

--- a/test/SetHostIp4.cpp
+++ b/test/SetHostIp4.cpp
@@ -58,7 +58,7 @@ static void assertUriEqual(const UriUriA * uri, const char * expected) {
 }
 
 static void assertUriHostIp4Equal(const UriUriA * uri, unsigned char o1, unsigned char o2,
-                                  unsigned char o3, unsigned char o4) {
+        unsigned char o3, unsigned char o4) {
     ASSERT_TRUE(uri->hostData.ip4 != NULL);
     EXPECT_EQ(uri->hostData.ip4->data[0], o1);
     EXPECT_EQ(uri->hostData.ip4->data[1], o2);

--- a/test/SetHostIp4.cpp
+++ b/test/SetHostIp4.cpp
@@ -27,7 +27,7 @@ namespace {
 static void testIsWellFormedHostIp4(const char * candidate, bool expectedWellFormed) {
     const char * const first = candidate;
     const char * const afterLast =
-        (candidate == NULL) ? NULL : (candidate + strlen(candidate));
+            (candidate == NULL) ? NULL : (candidate + strlen(candidate));
 
     const UriBool actualWellFormed = uriIsWellFormedHostIp4A(first, afterLast);
 

--- a/test/SetHostIp6.cpp
+++ b/test/SetHostIp6.cpp
@@ -117,7 +117,7 @@ TEST(IsWellFormedHostIp6, Lowercase) {
 TEST(IsWellFormedHostIp6, MaxLengthViolation) {
     testIsWellFormedHostIp6("aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa"
                             "X",
-                            false);
+            false);
 }
 
 TEST(IsWellFormedHostIp6, NineQuads) {

--- a/test/SetHostIp6.cpp
+++ b/test/SetHostIp6.cpp
@@ -27,10 +27,11 @@ namespace {
 static void testIsWellFormedHostIp6(const char * candidate, bool expectedWellFormed) {
     const char * const first = candidate;
     const char * const afterLast =
-        (candidate == NULL) ? NULL : (candidate + strlen(candidate));
+            (candidate == NULL) ? NULL : (candidate + strlen(candidate));
 
     const UriBool actualWellFormed =
-        (uriIsWellFormedHostIp6A(first, afterLast) == URI_SUCCESS) ? URI_TRUE : URI_FALSE;
+            (uriIsWellFormedHostIp6A(first, afterLast) == URI_SUCCESS) ? URI_TRUE
+                                                                       : URI_FALSE;
 
     ASSERT_EQ(actualWellFormed, expectedWellFormed);
 }

--- a/test/SetHostIpFuture.cpp
+++ b/test/SetHostIpFuture.cpp
@@ -28,11 +28,11 @@ static void testIsWellFormedHostIpFuture(const char * candidate,
                                          bool expectedWellFormed) {
     const char * const first = candidate;
     const char * const afterLast =
-        (candidate == NULL) ? NULL : (candidate + strlen(candidate));
+            (candidate == NULL) ? NULL : (candidate + strlen(candidate));
 
     const UriBool actualWellFormed =
-        (uriIsWellFormedHostIpFutureA(first, afterLast) == URI_SUCCESS) ? URI_TRUE
-                                                                        : URI_FALSE;
+            (uriIsWellFormedHostIpFutureA(first, afterLast) == URI_SUCCESS) ? URI_TRUE
+                                                                            : URI_FALSE;
 
     ASSERT_EQ(actualWellFormed, expectedWellFormed);
 }

--- a/test/SetHostIpFuture.cpp
+++ b/test/SetHostIpFuture.cpp
@@ -24,8 +24,8 @@
 
 namespace {
 
-static void testIsWellFormedHostIpFuture(const char * candidate,
-                                         bool expectedWellFormed) {
+static void testIsWellFormedHostIpFuture(
+        const char * candidate, bool expectedWellFormed) {
     const char * const first = candidate;
     const char * const afterLast =
             (candidate == NULL) ? NULL : (candidate + strlen(candidate));

--- a/test/SetHostRegName.cpp
+++ b/test/SetHostRegName.cpp
@@ -83,7 +83,7 @@ TEST(IsWellFormedHostRegName, AllowedCharacters) {
                                 "gGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ"
                                 "-._~"
                                 "!$&'()*+,;=",
-                                true);
+            true);
 }
 
 TEST(IsWellFormedHostRegName, ForbiddenCharacters) {
@@ -95,7 +95,7 @@ TEST(IsWellFormedHostRegName, PercentEncodingWellFormed) {
                                 "aa"
                                 "%"
                                 "AA",
-                                true);
+            true);
 }
 
 TEST(IsWellFormedHostRegName, PercentEncodingMalformedCutOff1) {
@@ -105,19 +105,19 @@ TEST(IsWellFormedHostRegName, PercentEncodingMalformedCutOff1) {
 TEST(IsWellFormedHostRegName, PercentEncodingMalformedCutOff2) {
     testIsWellFormedHostRegName("%"
                                 "a",
-                                false);
+            false);
 }
 
 TEST(IsWellFormedHostRegName, PercentEncodingMalformedForbiddenCharacter1) {
     testIsWellFormedHostRegName("%"
                                 "ga",
-                                false);
+            false);
 }
 
 TEST(IsWellFormedHostRegName, PercentEncodingMalformedForbiddenCharacter2) {
     testIsWellFormedHostRegName("%"
                                 "ag",
-                                false);
+            false);
 }
 
 TEST(SetHostRegName, NullUriOnly) {

--- a/test/SetHostRegName.cpp
+++ b/test/SetHostRegName.cpp
@@ -27,7 +27,7 @@ namespace {
 static void testIsWellFormedHostRegName(const char * candidate, bool expectedWellFormed) {
     const char * const first = candidate;
     const char * const afterLast =
-        (candidate == NULL) ? NULL : (candidate + strlen(candidate));
+            (candidate == NULL) ? NULL : (candidate + strlen(candidate));
 
     const UriBool actualWellFormed = uriIsWellFormedHostRegNameA(first, afterLast);
 

--- a/test/SetPath.cpp
+++ b/test/SetPath.cpp
@@ -28,8 +28,8 @@
 
 namespace {
 
-static void testIsWellFormedPath(const char * candidate, bool hasHost,
-                                 bool expectedWellFormed) {
+static void testIsWellFormedPath(
+        const char * candidate, bool hasHost, bool expectedWellFormed) {
     const char * const first = candidate;
     const char * const afterLast =
             (candidate == NULL) ? NULL : (candidate + strlen(candidate));
@@ -115,7 +115,7 @@ TEST(IsWellFormedPath, AllowedCharacters) {
                              "-._~"
                              "!$&'()*+,;="
                              ":@",
-                             hasHost, true);
+                hasHost, true);
     }
 }
 
@@ -138,7 +138,7 @@ TEST(IsWellFormedPath, PercentEncodingWellFormed) {
                              "aa"
                              "%"
                              "AA",
-                             hasHost, true);
+                hasHost, true);
     }
 }
 
@@ -148,7 +148,7 @@ TEST(IsWellFormedPath, PercentEncodingMalformedCutOff1) {
         const UriBool hasHost = hasHostValues[i] ? URI_TRUE : URI_FALSE;
         testIsWellFormedPath("/"
                              "%",
-                             hasHost, false);
+                hasHost, false);
     }
 }
 
@@ -159,7 +159,7 @@ TEST(IsWellFormedPath, PercentEncodingMalformedCutOff2) {
         testIsWellFormedPath("/"
                              "%"
                              "a",
-                             hasHost, false);
+                hasHost, false);
     }
 }
 
@@ -170,7 +170,7 @@ TEST(IsWellFormedPath, PercentEncodingMalformedForbiddenCharacter1) {
         testIsWellFormedPath("/"
                              "%"
                              "ga",
-                             hasHost, false);
+                hasHost, false);
     }
 }
 
@@ -181,7 +181,7 @@ TEST(IsWellFormedPath, PercentEncodingMalformedForbiddenCharacter2) {
         testIsWellFormedPath("/"
                              "%"
                              "ag",
-                             hasHost, false);
+                hasHost, false);
     }
 }
 

--- a/test/SetPath.cpp
+++ b/test/SetPath.cpp
@@ -32,7 +32,7 @@ static void testIsWellFormedPath(const char * candidate, bool hasHost,
                                  bool expectedWellFormed) {
     const char * const first = candidate;
     const char * const afterLast =
-        (candidate == NULL) ? NULL : (candidate + strlen(candidate));
+            (candidate == NULL) ? NULL : (candidate + strlen(candidate));
 
     const UriBool actualWellFormed = uriIsWellFormedPathA(first, afterLast, hasHost);
 

--- a/test/SetPort.cpp
+++ b/test/SetPort.cpp
@@ -31,7 +31,7 @@ namespace {
 static void testIsWellFormedPort(const char * candidate, bool expectedWellFormed) {
     const char * const first = candidate;
     const char * const afterLast =
-        (candidate == NULL) ? NULL : (candidate + strlen(candidate));
+            (candidate == NULL) ? NULL : (candidate + strlen(candidate));
 
     const UriBool actualWellFormed = uriIsWellFormedPortA(first, afterLast);
 

--- a/test/SetQuery.cpp
+++ b/test/SetQuery.cpp
@@ -90,7 +90,7 @@ TEST(IsWellFormedQuery, AllowedCharacters) {
                           "!$&'()*+,;="
                           ":@"
                           "/?",
-                          true);
+            true);
 }
 
 TEST(IsWellFormedQuery, ForbiddenCharacters) {
@@ -103,7 +103,7 @@ TEST(IsWellFormedQuery, PercentEncodingWellFormed) {
                           "aa"
                           "%"
                           "AA",
-                          true);
+            true);
 }
 
 TEST(IsWellFormedQuery, PercentEncodingMalformedCutOff1) {
@@ -113,19 +113,19 @@ TEST(IsWellFormedQuery, PercentEncodingMalformedCutOff1) {
 TEST(IsWellFormedQuery, PercentEncodingMalformedCutOff2) {
     testIsWellFormedQuery("%"
                           "a",
-                          false);
+            false);
 }
 
 TEST(IsWellFormedQuery, PercentEncodingMalformedForbiddenCharacter1) {
     testIsWellFormedQuery("%"
                           "ga",
-                          false);
+            false);
 }
 
 TEST(IsWellFormedQuery, PercentEncodingMalformedForbiddenCharacter2) {
     testIsWellFormedQuery("%"
                           "ag",
-                          false);
+            false);
 }
 
 TEST(SetQuery, NullUriOnly) {

--- a/test/SetQuery.cpp
+++ b/test/SetQuery.cpp
@@ -31,7 +31,7 @@ namespace {
 static void testIsWellFormedQuery(const char * candidate, bool expectedWellFormed) {
     const char * const first = candidate;
     const char * const afterLast =
-        (candidate == NULL) ? NULL : (candidate + strlen(candidate));
+            (candidate == NULL) ? NULL : (candidate + strlen(candidate));
 
     const UriBool actualWellFormed = uriIsWellFormedQueryA(first, afterLast);
 

--- a/test/SetScheme.cpp
+++ b/test/SetScheme.cpp
@@ -81,7 +81,7 @@ TEST(IsWellFormedScheme, AllowedCharacters) {
                            "gGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ"
                            "0123456789"
                            "+-.",
-                           true);
+            true);
 }
 
 TEST(IsWellFormedScheme, ForbiddenCharacters) {

--- a/test/SetScheme.cpp
+++ b/test/SetScheme.cpp
@@ -31,7 +31,7 @@ namespace {
 static void testIsWellFormedScheme(const char * candidate, bool expectedWellFormed) {
     const char * const first = candidate;
     const char * const afterLast =
-        (candidate == NULL) ? NULL : (candidate + strlen(candidate));
+            (candidate == NULL) ? NULL : (candidate + strlen(candidate));
 
     const UriBool actualWellFormed = uriIsWellFormedSchemeA(first, afterLast);
 

--- a/test/SetUserInfo.cpp
+++ b/test/SetUserInfo.cpp
@@ -31,7 +31,7 @@ namespace {
 static void testIsWellFormedUserInfo(const char * candidate, bool expectedWellFormed) {
     const char * const first = candidate;
     const char * const afterLast =
-        (candidate == NULL) ? NULL : (candidate + strlen(candidate));
+            (candidate == NULL) ? NULL : (candidate + strlen(candidate));
 
     const UriBool actualWellFormed = uriIsWellFormedUserInfoA(first, afterLast);
 

--- a/test/SetUserInfo.cpp
+++ b/test/SetUserInfo.cpp
@@ -88,7 +88,7 @@ TEST(IsWellFormedUserInfo, AllowedCharacters) {
                              "-._~"
                              "!$&'()*+,;="
                              ":",
-                             true);
+            true);
 }
 
 TEST(IsWellFormedUserInfo, ForbiddenCharacters) {
@@ -100,7 +100,7 @@ TEST(IsWellFormedUserInfo, PercentEncodingWellFormed) {
                              "aa"
                              "%"
                              "AA",
-                             true);
+            true);
 }
 
 TEST(IsWellFormedUserInfo, PercentEncodingMalformedCutOff1) {
@@ -110,19 +110,19 @@ TEST(IsWellFormedUserInfo, PercentEncodingMalformedCutOff1) {
 TEST(IsWellFormedUserInfo, PercentEncodingMalformedCutOff2) {
     testIsWellFormedUserInfo("%"
                              "a",
-                             false);
+            false);
 }
 
 TEST(IsWellFormedUserInfo, PercentEncodingMalformedForbiddenCharacter1) {
     testIsWellFormedUserInfo("%"
                              "ga",
-                             false);
+            false);
 }
 
 TEST(IsWellFormedUserInfo, PercentEncodingMalformedForbiddenCharacter2) {
     testIsWellFormedUserInfo("%"
                              "ag",
-                             false);
+            false);
 }
 
 TEST(SetUserInfo, NullUriOnly) {
@@ -231,8 +231,8 @@ TEST(SetUserInfo, UriWithoutHostNonNullRejected) {
     const char * const afterLast = first + strlen(first);
     EXPECT_TRUE(uri.hostText.first == NULL);  // self-test
 
-    EXPECT_EQ(uriSetUserInfoA(&uri, first, afterLast),
-              URI_ERROR_SETUSERINFO_HOST_NOT_SET);
+    EXPECT_EQ(
+            uriSetUserInfoA(&uri, first, afterLast), URI_ERROR_SETUSERINFO_HOST_NOT_SET);
 
     uriFreeUriMembersA(&uri);
 }

--- a/test/VersionSuite.cpp
+++ b/test/VersionSuite.cpp
@@ -28,8 +28,8 @@
 TEST(VersionSuite, EnsureVersionDefinesInSync) {
     char INSIDE_VERSION[256];
     const int bytes_printed =
-        sprintf(INSIDE_VERSION, "%d.%d.%d%s", URI_VER_MAJOR, URI_VER_MINOR,
-                URI_VER_RELEASE, URI_VER_SUFFIX_ANSI);
+            sprintf(INSIDE_VERSION, "%d.%d.%d%s", URI_VER_MAJOR, URI_VER_MINOR,
+                    URI_VER_RELEASE, URI_VER_SUFFIX_ANSI);
     ASSERT_NE(bytes_printed, -1);
     EXPECT_STREQ(INSIDE_VERSION, PACKAGE_VERSION);
 }

--- a/test/VersionSuite.cpp
+++ b/test/VersionSuite.cpp
@@ -27,9 +27,8 @@
 
 TEST(VersionSuite, EnsureVersionDefinesInSync) {
     char INSIDE_VERSION[256];
-    const int bytes_printed =
-            sprintf(INSIDE_VERSION, "%d.%d.%d%s", URI_VER_MAJOR, URI_VER_MINOR,
-                    URI_VER_RELEASE, URI_VER_SUFFIX_ANSI);
+    const int bytes_printed = sprintf(INSIDE_VERSION, "%d.%d.%d%s", URI_VER_MAJOR,
+            URI_VER_MINOR, URI_VER_RELEASE, URI_VER_SUFFIX_ANSI);
     ASSERT_NE(bytes_printed, -1);
     EXPECT_STREQ(INSIDE_VERSION, PACKAGE_VERSION);
 }

--- a/test/copy.cpp
+++ b/test/copy.cpp
@@ -70,7 +70,7 @@ TEST(CopyUriSuite, ErrorIncompleteMemoryManager) {
 
     UriUriA destUri;
     ASSERT_EQ(URI_ERROR_MEMORY_MANAGER_INCOMPLETE,
-              uriCopyUriMmA(&destUri, &sourceUri, &memory));
+            uriCopyUriMmA(&destUri, &sourceUri, &memory));
 
     uriFreeUriMembersA(&sourceUri);
 }
@@ -127,18 +127,18 @@ TEST(CopyUriSuite, SuccessIpV4) {
 TEST(CopyUriSuite, SuccessIpV6) {
     UriUriA destUri;
     testCopyUri(&destUri,
-                "https://[2001:0db8:0001:0000:0000:0ab9:c0a8:0102]");  // RFC 3849
+            "https://[2001:0db8:0001:0000:0000:0ab9:c0a8:0102]");  // RFC 3849
 
     const unsigned char expected[16] = {0x20, 0x01, 0x0d, 0xb8, 0x00, 0x01, 0x00, 0x00,
-                                        0x00, 0x00, 0x0a, 0xb9, 0xc0, 0xa8, 0x01, 0x02};
+            0x00, 0x00, 0x0a, 0xb9, 0xc0, 0xa8, 0x01, 0x02};
     ASSERT_EQ(memcmp(expected, destUri.hostData.ip6->data, sizeof(expected)), 0);
 
     ASSERT_TRUE(destUri.hostData.ip4 == NULL);
     ASSERT_TRUE(destUri.hostData.ipFuture.first == NULL);
     ASSERT_TRUE(destUri.hostData.ipFuture.afterLast == NULL);
-    ASSERT_EQ(0,
-              strncmp(destUri.hostText.first, "2001:0db8:0001:0000:0000:0ab9:c0a8:0102",
-                      strlen("2001:0db8:0001:0000:0000:0ab9:c0a8:0102")));
+    ASSERT_EQ(
+            0, strncmp(destUri.hostText.first, "2001:0db8:0001:0000:0000:0ab9:c0a8:0102",
+                       strlen("2001:0db8:0001:0000:0000:0ab9:c0a8:0102")));
 
     uriFreeUriMembersA(&destUri);
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -62,7 +62,7 @@ bool uriRangeEqualsA(const UriTextRangeA * a, const UriTextRangeA * b);
 
 namespace {
 bool testDistinctionHelper(const char * uriText, bool expectedHostSet,
-                           bool expectedAbsPath, bool expectedEmptyTailSegment) {
+        bool expectedAbsPath, bool expectedEmptyTailSegment) {
     UriParserStateA state;
     UriUriA uri;
     state.uri = &uri;
@@ -84,8 +84,8 @@ bool testDistinctionHelper(const char * uriText, bool expectedHostSet,
     }
 
     if (expectedEmptyTailSegment
-        != ((uri.pathTail != NULL)
-            && (uri.pathTail->text.first == uri.pathTail->text.afterLast))) {
+            != ((uri.pathTail != NULL)
+                    && (uri.pathTail->text.first == uri.pathTail->text.afterLast))) {
         uriFreeUriMembersA(&uri);
         return false;
     }
@@ -305,7 +305,7 @@ TEST(UriSuite, TestIpSixOverread) {
     memcpy(uriText, "//[::44.1", sizeof(uriText));
 
     EXPECT_EQ(uriParseSingleUriExA(&uri, uriText, uriText + sizeof(uriText), &errorPos),
-              URI_ERROR_SYNTAX);
+            URI_ERROR_SYNTAX);
     EXPECT_EQ(errorPos, uriText + sizeof(uriText));
 }
 
@@ -319,21 +319,21 @@ TEST(UriSuite, TestUri) {
     stateW.uri = &uriW;
 
     // On/off for each
-    ASSERT_EQ(0, uriParseUriA(&stateA,
-                              "//user:pass@[::1]:80/segment/index.html?query#frag"));
+    ASSERT_EQ(0,
+            uriParseUriA(&stateA, "//user:pass@[::1]:80/segment/index.html?query#frag"));
     uriFreeUriMembersA(&uriA);
     ASSERT_EQ(0, uriParseUriA(&stateA, "http://[::1]:80/segment/index.html?query#frag"));
     uriFreeUriMembersA(&uriA);
     ASSERT_EQ(0, uriParseUriA(&stateA,
-                              "http://user:pass@[::1]/segment/index.html?query#frag"));
+                         "http://user:pass@[::1]/segment/index.html?query#frag"));
     uriFreeUriMembersA(&uriA);
     ASSERT_EQ(0, uriParseUriA(&stateA, "http://user:pass@[::1]:80?query#frag"));
     uriFreeUriMembersA(&uriA);
     ASSERT_EQ(0,
-              uriParseUriA(&stateA, "http://user:pass@[::1]:80/segment/index.html#frag"));
+            uriParseUriA(&stateA, "http://user:pass@[::1]:80/segment/index.html#frag"));
     uriFreeUriMembersA(&uriA);
-    ASSERT_EQ(0, uriParseUriA(&stateA,
-                              "http://user:pass@[::1]:80/segment/index.html?query"));
+    ASSERT_EQ(0,
+            uriParseUriA(&stateA, "http://user:pass@[::1]:80/segment/index.html?query"));
     uriFreeUriMembersA(&uriA);
 
     // Schema, port, one segment
@@ -887,10 +887,10 @@ TEST(UriSuite, TestUriHostIpFuture) {
 
 namespace {
 bool testEscapingHelper(const wchar_t * in, const wchar_t * expectedOut,
-                        bool spaceToPlus = false, bool normalizeBreaks = false) {
+        bool spaceToPlus = false, bool normalizeBreaks = false) {
     wchar_t * const buffer = new wchar_t[(normalizeBreaks ? 6 : 3) * wcslen(in) + 1];
     if (uriEscapeW(in, buffer, spaceToPlus, normalizeBreaks)
-        != buffer + wcslen(expectedOut)) {
+            != buffer + wcslen(expectedOut)) {
         delete[] buffer;
         return false;
     }
@@ -957,8 +957,8 @@ TEST(UriSuite, TestEscaping) {
 
 namespace {
 bool testUnescapingHelper(const wchar_t * input, const wchar_t * output,
-                          bool plusToSpace = false,
-                          UriBreakConversion breakConversion = URI_BR_DONT_TOUCH) {
+        bool plusToSpace = false,
+        UriBreakConversion breakConversion = URI_BR_DONT_TOUCH) {
     wchar_t * working = new wchar_t[URI_STRLEN(input) + 1];
     wcscpy(working, input);
     const wchar_t * newTermZero = uriUnescapeInPlaceExW(
@@ -994,113 +994,112 @@ TEST(UriSuite, TestUnescaping) {
 
     // Line break conversion
     ASSERT_TRUE(testUnescapingHelper(L"%0d", L"\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d", L"\x0d\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d", L"\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
     ASSERT_TRUE(testUnescapingHelper(L"%0d", L"\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
     ASSERT_TRUE(
             testUnescapingHelper(L"%0d", L"\x0d", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0d", L"\x0a\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_UNIX));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0d", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0d", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0d", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
     ASSERT_TRUE(
             testUnescapingHelper(L"%0d%0d", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0d", L"\x0d\x0d", PLUS_DONT_TOUCH,
-                                     URI_BR_DONT_TOUCH));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0d", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 
     ASSERT_TRUE(testUnescapingHelper(L"%0a", L"\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
-    ASSERT_TRUE(testUnescapingHelper(L"%0a", L"\x0d\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a", L"\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
     ASSERT_TRUE(testUnescapingHelper(L"%0a", L"\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
     ASSERT_TRUE(
             testUnescapingHelper(L"%0a", L"\x0a", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0a", L"\x0a\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_UNIX));
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0a", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0a", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0a", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
     ASSERT_TRUE(
             testUnescapingHelper(L"%0a%0a", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0a", L"\x0a\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_DONT_TOUCH));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0a", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 
     ASSERT_TRUE(
             testUnescapingHelper(L"%0d%0a", L"\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a", L"\x0d\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0a", L"\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
     ASSERT_TRUE(testUnescapingHelper(L"%0d%0a", L"\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a", L"\x0d\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_DONT_TOUCH));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0a", L"\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0a", L"\x0a\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_UNIX));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0a", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_WINDOWS));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0a", L"\x0d\x0d", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_MAC));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0a", L"\x0d\x0a\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_DONT_TOUCH));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0a%0a", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0a%0a", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0a%0a", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0a%0a", L"\x0d\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0d", L"\x0a\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_UNIX));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0d", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_WINDOWS));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0d", L"\x0d\x0d", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_MAC));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0d", L"\x0d\x0a\x0d", PLUS_DONT_TOUCH,
-                                     URI_BR_DONT_TOUCH));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0a%0d", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0a%0d", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0a%0d", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0a%0d", L"\x0d\x0a\x0d", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0d%0a", L"\x0a\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_UNIX));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0d%0a", L"\x0d\x0a\x0d\x0a",
-                                     PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0d%0a", L"\x0d\x0d", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_MAC));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0d%0a", L"\x0d\x0a\x0d\x0a",
-                                     PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0a%0d%0a", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0a%0d%0a", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0a%0d%0a", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0d%0a%0d%0a", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d", L"\x0a\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_UNIX));
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0d", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0d", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
     ASSERT_TRUE(
             testUnescapingHelper(L"%0a%0d", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d", L"\x0a\x0d", PLUS_DONT_TOUCH,
-                                     URI_BR_DONT_TOUCH));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0d", L"\x0a\x0d", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0a", L"\x0a\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_UNIX));
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0a", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_WINDOWS));
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0a", L"\x0d\x0d", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_MAC));
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0a", L"\x0a\x0d\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_DONT_TOUCH));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0d%0a", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0d%0a", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0d%0a", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0d%0a", L"\x0a\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0d", L"\x0a\x0a\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0d%0d", L"\x0a\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
     ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0d", L"\x0d\x0a\x0d\x0a\x0d\x0a",
-                                     PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0d", L"\x0d\x0d\x0d", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_MAC));
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0d", L"\x0a\x0d\x0d", PLUS_DONT_TOUCH,
-                                     URI_BR_DONT_TOUCH));
+            PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0d%0d", L"\x0d\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0d%0d", L"\x0a\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0a%0d", L"\x0a\x0a\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0d%0a%0d", L"\x0a\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
     ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0a%0d", L"\x0d\x0a\x0d\x0a\x0d\x0a",
-                                     PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0a%0d", L"\x0d\x0d\x0d", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_MAC));
-    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0a%0d", L"\x0a\x0d\x0a\x0d",
-                                     PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
+            PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0d%0a%0d", L"\x0d\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
+    ASSERT_TRUE(testUnescapingHelper(
+            L"%0a%0d%0a%0d", L"\x0a\x0d\x0a\x0d", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 }
 
 namespace {
 bool testAddBaseHelper(const wchar_t * base, const wchar_t * rel,
-                       const wchar_t * expectedResult,
-                       bool backward_compatibility = false) {
+        const wchar_t * expectedResult, bool backward_compatibility = false) {
     UriParserStateW stateW;
 
     // Base
@@ -1136,8 +1135,8 @@ bool testAddBaseHelper(const wchar_t * base, const wchar_t * rel,
     // Transform
     UriUriW transformedUri;
     if (backward_compatibility) {
-        res = uriAddBaseUriExW(&transformedUri, &relUri, &baseUri,
-                               URI_RESOLVE_IDENTICAL_SCHEME_COMPAT);
+        res = uriAddBaseUriExW(
+                &transformedUri, &relUri, &baseUri, URI_RESOLVE_IDENTICAL_SCHEME_COMPAT);
     } else {
         res = uriAddBaseUriW(&transformedUri, &relUri, &baseUri);
     }
@@ -1204,8 +1203,8 @@ TEST(UriSuite, TestAddBase) {
             testAddBaseHelper(L"http://a/b/c/d;p?q", L"g?y#s", L"http://a/b/c/g?y#s"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L";x", L"http://a/b/c/;x"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g;x", L"http://a/b/c/g;x"));
-    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g;x?y#s",
-                                  L"http://a/b/c/g;x?y#s"));
+    ASSERT_TRUE(testAddBaseHelper(
+            L"http://a/b/c/d;p?q", L"g;x?y#s", L"http://a/b/c/g;x?y#s"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"", L"http://a/b/c/d;p?q"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L".", L"http://a/b/c/"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"./", L"http://a/b/c/"));
@@ -1230,28 +1229,28 @@ TEST(UriSuite, TestAddBase) {
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"./g/.", L"http://a/b/c/g/"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g/./h", L"http://a/b/c/g/h"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g/../h", L"http://a/b/c/h"));
-    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g;x=1/./y",
-                                  L"http://a/b/c/g;x=1/y"));
+    ASSERT_TRUE(testAddBaseHelper(
+            L"http://a/b/c/d;p?q", L"g;x=1/./y", L"http://a/b/c/g;x=1/y"));
     ASSERT_TRUE(
             testAddBaseHelper(L"http://a/b/c/d;p?q", L"g;x=1/../y", L"http://a/b/c/y"));
-    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g?y/./x",
-                                  L"http://a/b/c/g?y/./x"));
-    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g?y/../x",
-                                  L"http://a/b/c/g?y/../x"));
-    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g#s/./x",
-                                  L"http://a/b/c/g#s/./x"));
-    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g#s/../x",
-                                  L"http://a/b/c/g#s/../x"));
+    ASSERT_TRUE(testAddBaseHelper(
+            L"http://a/b/c/d;p?q", L"g?y/./x", L"http://a/b/c/g?y/./x"));
+    ASSERT_TRUE(testAddBaseHelper(
+            L"http://a/b/c/d;p?q", L"g?y/../x", L"http://a/b/c/g?y/../x"));
+    ASSERT_TRUE(testAddBaseHelper(
+            L"http://a/b/c/d;p?q", L"g#s/./x", L"http://a/b/c/g#s/./x"));
+    ASSERT_TRUE(testAddBaseHelper(
+            L"http://a/b/c/d;p?q", L"g#s/../x", L"http://a/b/c/g#s/../x"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"http:g", L"http:g"));
 
     // Backward compatibility (feature request #4, RFC3986 5.4.2)
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"http:g", L"http:g", false));
     ASSERT_TRUE(
             testAddBaseHelper(L"http://a/b/c/d;p?q", L"http:g", L"http://a/b/c/g", true));
-    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"http:g?q#f",
-                                  L"http://a/b/c/g?q#f", true));
-    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"other:g?q#f", L"other:g?q#f",
-                                  true));
+    ASSERT_TRUE(testAddBaseHelper(
+            L"http://a/b/c/d;p?q", L"http:g?q#f", L"http://a/b/c/g?q#f", true));
+    ASSERT_TRUE(testAddBaseHelper(
+            L"http://a/b/c/d;p?q", L"other:g?q#f", L"other:g?q#f", true));
 
     // Bug related to absolutePath flag set despite presence of host
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"/", L"http://a/"));
@@ -1518,8 +1517,8 @@ TEST(UriSuite, TestNormalizeSyntaxMaskRequiredPort) {
 
 namespace {
 bool testNormalizeSyntaxHelper(const wchar_t * uriText,
-                               const wchar_t * expectedNormalized,
-                               unsigned int mask = static_cast<unsigned int>(-1)) {
+        const wchar_t * expectedNormalized,
+        unsigned int mask = static_cast<unsigned int>(-1)) {
     UriParserStateW stateW;
     int res;
 
@@ -1568,30 +1567,30 @@ bool testNormalizeSyntaxHelper(const wchar_t * uriText,
 }  // namespace
 
 TEST(UriSuite, TestNormalizeSyntax) {
-    ASSERT_TRUE(testNormalizeSyntaxHelper(L"eXAMPLE://a/./b/../b/%63/%7bfoo%7d",
-                                          L"example://a/b/c/%7Bfoo%7D"));
+    ASSERT_TRUE(testNormalizeSyntaxHelper(
+            L"eXAMPLE://a/./b/../b/%63/%7bfoo%7d", L"example://a/b/c/%7Bfoo%7D"));
 
     // Testcase by Adrian Manrique
     ASSERT_TRUE(
             testNormalizeSyntaxHelper(L"http://examp%4Ce.com/", L"http://example.com/"));
 
     // Testcase by Adrian Manrique
-    ASSERT_TRUE(testNormalizeSyntaxHelper(L"http://example.com/a/b/%2E%2E/",
-                                          L"http://example.com/a/"));
+    ASSERT_TRUE(testNormalizeSyntaxHelper(
+            L"http://example.com/a/b/%2E%2E/", L"http://example.com/a/"));
 
     // Reported by Adrian Manrique
-    ASSERT_TRUE(testNormalizeSyntaxHelper(L"http://user:pass@SOMEHOST.COM:123",
-                                          L"http://user:pass@somehost.com:123"));
-
     ASSERT_TRUE(testNormalizeSyntaxHelper(
-            L"https://%e4%bd%a0%e5%a5%bd%e4%bd%a0%e5%a5%bd.com",
-            L"https://%E4%BD%A0%E5%A5%BD%E4%BD%A0%E5%A5%BD.com"));
+            L"http://user:pass@SOMEHOST.COM:123", L"http://user:pass@somehost.com:123"));
+
+    ASSERT_TRUE(
+            testNormalizeSyntaxHelper(L"https://%e4%bd%a0%e5%a5%bd%e4%bd%a0%e5%a5%bd.com",
+                    L"https://%E4%BD%A0%E5%A5%BD%E4%BD%A0%E5%A5%BD.com"));
 
     ASSERT_TRUE(testNormalizeSyntaxHelper(L"https://[2041:0000:140F::875B:131B]",
-                                          L"https://[2041:0000:140f::875b:131b]"));
+            L"https://[2041:0000:140f::875b:131b]"));
 
     ASSERT_TRUE(testNormalizeSyntaxHelper(L"HTTP://a:b@HOST:123/./1/2/../%41?abc#def",
-                                          L"http://a:b@host:123/1/A?abc#def"));
+            L"http://a:b@host:123/1/A?abc#def"));
 
     ASSERT_TRUE(testNormalizeSyntaxHelper(L"../../abc", L"../../abc"));
 
@@ -1614,65 +1613,59 @@ TEST(UriSuite, TestNormalizeSyntax) {
 
 TEST(UriSuite, TestNormalizeSyntaxComponents) {
     ASSERT_TRUE(testNormalizeSyntaxHelper(L"HTTP://%41@EXAMPLE.ORG/../a?%41#%41",
-                                          L"http://%41@EXAMPLE.ORG/../a?%41#%41",
-                                          URI_NORMALIZE_SCHEME));
+            L"http://%41@EXAMPLE.ORG/../a?%41#%41", URI_NORMALIZE_SCHEME));
 
     ASSERT_TRUE(testNormalizeSyntaxHelper(L"HTTP://%41@EXAMPLE.ORG/../a?%41#%41",
-                                          L"HTTP://A@EXAMPLE.ORG/../a?%41#%41",
-                                          URI_NORMALIZE_USER_INFO));
+            L"HTTP://A@EXAMPLE.ORG/../a?%41#%41", URI_NORMALIZE_USER_INFO));
 
     ASSERT_TRUE(testNormalizeSyntaxHelper(L"HTTP://%41@EXAMPLE.ORG/../a?%41#%41",
-                                          L"HTTP://%41@example.org/../a?%41#%41",
-                                          URI_NORMALIZE_HOST));
+            L"HTTP://%41@example.org/../a?%41#%41", URI_NORMALIZE_HOST));
 
-    ASSERT_TRUE(testNormalizeSyntaxHelper(L"HTTP://EXAMPLE.ORG:00080/",
-                                          L"HTTP://EXAMPLE.ORG:80/", URI_NORMALIZE_PORT));
-
-    ASSERT_TRUE(testNormalizeSyntaxHelper(L"HTTP://%41@EXAMPLE.ORG/../a?%41#%41",
-                                          L"HTTP://%41@EXAMPLE.ORG/a?%41#%41",
-                                          URI_NORMALIZE_PATH));
+    ASSERT_TRUE(testNormalizeSyntaxHelper(
+            L"HTTP://EXAMPLE.ORG:00080/", L"HTTP://EXAMPLE.ORG:80/", URI_NORMALIZE_PORT));
 
     ASSERT_TRUE(testNormalizeSyntaxHelper(L"HTTP://%41@EXAMPLE.ORG/../a?%41#%41",
-                                          L"HTTP://%41@EXAMPLE.ORG/../a?A#%41",
-                                          URI_NORMALIZE_QUERY));
+            L"HTTP://%41@EXAMPLE.ORG/a?%41#%41", URI_NORMALIZE_PATH));
 
     ASSERT_TRUE(testNormalizeSyntaxHelper(L"HTTP://%41@EXAMPLE.ORG/../a?%41#%41",
-                                          L"HTTP://%41@EXAMPLE.ORG/../a?%41#A",
-                                          URI_NORMALIZE_FRAGMENT));
+            L"HTTP://%41@EXAMPLE.ORG/../a?A#%41", URI_NORMALIZE_QUERY));
+
+    ASSERT_TRUE(testNormalizeSyntaxHelper(L"HTTP://%41@EXAMPLE.ORG/../a?%41#%41",
+            L"HTTP://%41@EXAMPLE.ORG/../a?%41#A", URI_NORMALIZE_FRAGMENT));
 }
 
 TEST(UriSuite, TestNormalizeSyntaxPort) {
     // Empty port text unchanged
-    ASSERT_TRUE(testNormalizeSyntaxHelper(L"scheme://host:/", L"scheme://host:/",
-                                          URI_NORMALIZE_PORT));
+    ASSERT_TRUE(testNormalizeSyntaxHelper(
+            L"scheme://host:/", L"scheme://host:/", URI_NORMALIZE_PORT));
     // Zero port unchanged
-    ASSERT_TRUE(testNormalizeSyntaxHelper(L"scheme://host:0/", L"scheme://host:0/",
-                                          URI_NORMALIZE_PORT));
+    ASSERT_TRUE(testNormalizeSyntaxHelper(
+            L"scheme://host:0/", L"scheme://host:0/", URI_NORMALIZE_PORT));
     // All-zeros port turned into single zero
-    ASSERT_TRUE(testNormalizeSyntaxHelper(L"scheme://host:00/", L"scheme://host:0/",
-                                          URI_NORMALIZE_PORT));
+    ASSERT_TRUE(testNormalizeSyntaxHelper(
+            L"scheme://host:00/", L"scheme://host:0/", URI_NORMALIZE_PORT));
     // Leading zeros cut off
-    ASSERT_TRUE(testNormalizeSyntaxHelper(L"scheme://host:00080/", L"scheme://host:80/",
-                                          URI_NORMALIZE_PORT));
+    ASSERT_TRUE(testNormalizeSyntaxHelper(
+            L"scheme://host:00080/", L"scheme://host:80/", URI_NORMALIZE_PORT));
 }
 
 TEST(UriSuite, TestNormalizeSyntaxPath) {
     // These are from GitHub issue #92
-    EXPECT_TRUE(testNormalizeSyntaxHelper(L"http://a/b/c/../../..", L"http://a/",
-                                          URI_NORMALIZE_PATH));
-    EXPECT_TRUE(testNormalizeSyntaxHelper(L"http://a/b/../c/../..", L"http://a/",
-                                          URI_NORMALIZE_PATH));
-    EXPECT_TRUE(testNormalizeSyntaxHelper(L"http://a/b/c/../../..", L"http://a/",
-                                          URI_NORMALIZE_PATH));
+    EXPECT_TRUE(testNormalizeSyntaxHelper(
+            L"http://a/b/c/../../..", L"http://a/", URI_NORMALIZE_PATH));
+    EXPECT_TRUE(testNormalizeSyntaxHelper(
+            L"http://a/b/../c/../..", L"http://a/", URI_NORMALIZE_PATH));
+    EXPECT_TRUE(testNormalizeSyntaxHelper(
+            L"http://a/b/c/../../..", L"http://a/", URI_NORMALIZE_PATH));
 
     // .. and these are related
     EXPECT_TRUE(
             testNormalizeSyntaxHelper(L"http://a/..", L"http://a/", URI_NORMALIZE_PATH));
     EXPECT_TRUE(testNormalizeSyntaxHelper(L"/..", L"/", URI_NORMALIZE_PATH));
-    EXPECT_TRUE(testNormalizeSyntaxHelper(L"http://a/..///", L"http://a///",
-                                          URI_NORMALIZE_PATH));
-    EXPECT_TRUE(testNormalizeSyntaxHelper(L"http://a/..///..", L"http://a//",
-                                          URI_NORMALIZE_PATH));
+    EXPECT_TRUE(testNormalizeSyntaxHelper(
+            L"http://a/..///", L"http://a///", URI_NORMALIZE_PATH));
+    EXPECT_TRUE(testNormalizeSyntaxHelper(
+            L"http://a/..///..", L"http://a//", URI_NORMALIZE_PATH));
     EXPECT_TRUE(testNormalizeSyntaxHelper(L"a/b/c/../../..", L"", URI_NORMALIZE_PATH));
     EXPECT_TRUE(testNormalizeSyntaxHelper(L"a/b/../../c/..", L"", URI_NORMALIZE_PATH));
 }
@@ -1700,10 +1693,10 @@ TEST(UriSuite, TestNormalizeCrashBug20080224) {
 }
 
 TEST(UriSuite, TestNormalizeBug262Fixed) {
-    EXPECT_TRUE(testNormalizeSyntaxHelper(L"scheme:/.//foo/bar", L"scheme:/.//foo/bar",
-                                          URI_NORMALIZE_PATH));
-    EXPECT_TRUE(testNormalizeSyntaxHelper(L"/.//foo/bar", L"/.//foo/bar",
-                                          URI_NORMALIZE_PATH));
+    EXPECT_TRUE(testNormalizeSyntaxHelper(
+            L"scheme:/.//foo/bar", L"scheme:/.//foo/bar", URI_NORMALIZE_PATH));
+    EXPECT_TRUE(testNormalizeSyntaxHelper(
+            L"/.//foo/bar", L"/.//foo/bar", URI_NORMALIZE_PATH));
     EXPECT_TRUE(
             testNormalizeSyntaxHelper(L".//foo/bar", L".//foo/bar", URI_NORMALIZE_PATH));
 }
@@ -1711,30 +1704,29 @@ TEST(UriSuite, TestNormalizeBug262Fixed) {
 TEST(UriSuite, TestNormalizeBug262Unchanged) {
     // 3x same as TestNormalizeBug262Fixed above
     // but with a single slash rather than double slashes
-    EXPECT_TRUE(testNormalizeSyntaxHelper(L"scheme:/./foo/bar", L"scheme:/foo/bar",
-                                          URI_NORMALIZE_PATH));
+    EXPECT_TRUE(testNormalizeSyntaxHelper(
+            L"scheme:/./foo/bar", L"scheme:/foo/bar", URI_NORMALIZE_PATH));
     EXPECT_TRUE(
             testNormalizeSyntaxHelper(L"/./foo/bar", L"/foo/bar", URI_NORMALIZE_PATH));
     EXPECT_TRUE(testNormalizeSyntaxHelper(L"./foo/bar", L"foo/bar", URI_NORMALIZE_PATH));
 
     // 2x same as TestNormalizeBug262Fixed above
     // but with a host added
-    EXPECT_TRUE(testNormalizeSyntaxHelper(L"scheme://host/.//foo/bar",
-                                          L"scheme://host//foo/bar", URI_NORMALIZE_PATH));
-    EXPECT_TRUE(testNormalizeSyntaxHelper(L"//host/.//foo/bar", L"//host//foo/bar",
-                                          URI_NORMALIZE_PATH));
+    EXPECT_TRUE(testNormalizeSyntaxHelper(
+            L"scheme://host/.//foo/bar", L"scheme://host//foo/bar", URI_NORMALIZE_PATH));
+    EXPECT_TRUE(testNormalizeSyntaxHelper(
+            L"//host/.//foo/bar", L"//host//foo/bar", URI_NORMALIZE_PATH));
 
     // Second path segment containing a colon
-    EXPECT_TRUE(testNormalizeSyntaxHelper(L"scheme:./path1:/path2",
-                                          L"scheme:path1:/path2", URI_NORMALIZE_PATH));
-    EXPECT_TRUE(testNormalizeSyntaxHelper(L"./path1:/path2", L"./path1:/path2",
-                                          URI_NORMALIZE_PATH));
+    EXPECT_TRUE(testNormalizeSyntaxHelper(
+            L"scheme:./path1:/path2", L"scheme:path1:/path2", URI_NORMALIZE_PATH));
+    EXPECT_TRUE(testNormalizeSyntaxHelper(
+            L"./path1:/path2", L"./path1:/path2", URI_NORMALIZE_PATH));
 }
 
 namespace {
 void testFilenameUriConversionHelper(const wchar_t * filename, const wchar_t * uriString,
-                                     bool forUnix,
-                                     const wchar_t * expectedUriString = NULL) {
+        bool forUnix, const wchar_t * expectedUriString = NULL) {
     const int prefixLen = forUnix ? 7 : 8;
     if (!expectedUriString) {
         expectedUriString = uriString;
@@ -1768,16 +1760,14 @@ TEST(UriSuite, TestFilenameUriConversion) {
     const bool FOR_UNIX = true;
     const bool FOR_WINDOWS = false;
     testFilenameUriConversionHelper(L"/bin/bash", L"file:///bin/bash", FOR_UNIX);
-    testFilenameUriConversionHelper(L"/bin/bash", L"file:/bin/bash", FOR_UNIX,
-                                    L"file:///bin/bash");
+    testFilenameUriConversionHelper(
+            L"/bin/bash", L"file:/bin/bash", FOR_UNIX, L"file:///bin/bash");
     testFilenameUriConversionHelper(L"./configure", L"./configure", FOR_UNIX);
 
     testFilenameUriConversionHelper(L"E:\\Documents and Settings",
-                                    L"file:///E:/Documents%20and%20Settings",
-                                    FOR_WINDOWS);
+            L"file:///E:/Documents%20and%20Settings", FOR_WINDOWS);
     testFilenameUriConversionHelper(L"c:\\path\\to\\file.txt",
-                                    L"file:c:/path/to/file.txt", FOR_WINDOWS,
-                                    L"file:///c:/path/to/file.txt");
+            L"file:c:/path/to/file.txt", FOR_WINDOWS, L"file:///c:/path/to/file.txt");
 
     testFilenameUriConversionHelper(L".\\Readme.txt", L"./Readme.txt", FOR_WINDOWS);
 
@@ -1788,7 +1778,7 @@ TEST(UriSuite, TestFilenameUriConversion) {
     testFilenameUriConversionHelper(L"abc def", L"abc%20def", FOR_UNIX);
 
     testFilenameUriConversionHelper(L"\\\\Server01\\user\\docs\\Letter.txt",
-                                    L"file://Server01/user/docs/Letter.txt", FOR_WINDOWS);
+            L"file://Server01/user/docs/Letter.txt", FOR_WINDOWS);
 }
 
 TEST(UriSuite, TestCrashFreeUriMembersBug20080116) {
@@ -1821,8 +1811,8 @@ TEST(UriSuite, TestQueryStringEndingInEqualSignNonBug32) {
 
     UriQueryListA * queryList = NULL;
     int itemCount = 0;
-    const int res = uriDissectQueryMallocA(&queryList, &itemCount, queryString,
-                                           queryString + strlen(queryString));
+    const int res = uriDissectQueryMallocA(
+            &queryList, &itemCount, queryString, queryString + strlen(queryString));
 
     ASSERT_EQ(res, URI_SUCCESS);
     ASSERT_EQ(itemCount, 2);
@@ -1847,8 +1837,8 @@ void helperTestQueryString(char const * uriString, int pairsExpected) {
     UriQueryListA * queryList = NULL;
     int itemCount = 0;
 
-    res = uriDissectQueryMallocA(&queryList, &itemCount, uri.query.first,
-                                 uri.query.afterLast);
+    res = uriDissectQueryMallocA(
+            &queryList, &itemCount, uri.query.first, uri.query.afterLast);
     ASSERT_EQ(res, URI_SUCCESS);
     ASSERT_TRUE(queryList != NULL);
     ASSERT_EQ(itemCount, pairsExpected);
@@ -1884,7 +1874,7 @@ void testQueryListHelper(const wchar_t * input, int expectedItemCount) {
     int itemCount;
     UriQueryListW * queryList;
     res = uriDissectQueryMallocExW(&queryList, &itemCount, input, input + wcslen(input),
-                                   spacePlusConversion, breakConversion);
+            spacePlusConversion, breakConversion);
     ASSERT_EQ(res, URI_SUCCESS);
     ASSERT_EQ(itemCount, expectedItemCount);
     ASSERT_EQ((queryList == NULL), (expectedItemCount == 0));
@@ -1892,15 +1882,15 @@ void testQueryListHelper(const wchar_t * input, int expectedItemCount) {
     if (expectedItemCount != 0) {
         // First
         int charsRequired;
-        res = uriComposeQueryCharsRequiredExW(queryList, &charsRequired,
-                                              spacePlusConversion, normalizeBreaks);
+        res = uriComposeQueryCharsRequiredExW(
+                queryList, &charsRequired, spacePlusConversion, normalizeBreaks);
         ASSERT_EQ(res, URI_SUCCESS);
         ASSERT_TRUE(charsRequired >= (int)wcslen(input));
 
         wchar_t * recomposed = new wchar_t[charsRequired + 1];
         int charsWritten;
         res = uriComposeQueryExW(recomposed, queryList, charsRequired + 1, &charsWritten,
-                                 spacePlusConversion, normalizeBreaks);
+                spacePlusConversion, normalizeBreaks);
         ASSERT_EQ(res, URI_SUCCESS);
         ASSERT_TRUE(charsWritten <= charsRequired);
         ASSERT_EQ(charsWritten, (int)wcslen(input) + 1);
@@ -1931,7 +1921,7 @@ TEST(UriSuite, QueryList) {
 
 namespace {
 void testQueryListPairHelper(const char * pair, const char * unescapedKey,
-                             const char * unescapedValue, const char * fixed = NULL) {
+        const char * unescapedValue, const char * fixed = NULL) {
     int res;
     UriQueryListA * queryList;
     int itemCount;
@@ -1956,8 +1946,8 @@ void testQueryListPairHelper(const char * pair, const char * unescapedKey,
 TEST(UriSuite, TestQueryListPair) {
     testQueryListPairHelper("one+two+%26+three=%2B", "one two & three", "+");
     testQueryListPairHelper("one=two=three", "one", "two=three", "one=two%3Dthree");
-    testQueryListPairHelper("one=two=three=four", "one", "two=three=four",
-                            "one=two%3Dthree%3Dfour");
+    testQueryListPairHelper(
+            "one=two=three=four", "one", "two=three=four", "one=two%3Dthree%3Dfour");
 }
 
 TEST(UriSuite, TestQueryDissectionBug3590761) {
@@ -1994,8 +1984,8 @@ TEST(UriSuite, TestQueryCompositionMathCalc) {
 
     const int FACTOR = 6; /* due to escaping with normalizeBreaks */
     ASSERT_EQ((unsigned)charsRequired,
-              FACTOR * strlen(first.key) + 1 + FACTOR * strlen(first.value) + 1
-                      + FACTOR * strlen(second.key) + 1 + FACTOR * strlen(second.value));
+            FACTOR * strlen(first.key) + 1 + FACTOR * strlen(first.value) + 1
+                    + FACTOR * strlen(second.key) + 1 + FACTOR * strlen(second.value));
 }
 
 TEST(UriSuite, TestQueryCompositionMathWriteGoogleAutofuzz113244572) {
@@ -2015,7 +2005,7 @@ TEST(UriSuite, TestQueryCompositionMathWriteGoogleAutofuzz113244572) {
         char dest[charsRequired + 1];
         int charsWritten;
         ASSERT_TRUE(uriComposeQueryExA(dest, &first, sizeof(dest), &charsWritten,
-                                       spaceToPlus, normalizeBreaks)
+                            spaceToPlus, normalizeBreaks)
                     == URI_SUCCESS);
         EXPECT_STREQ(dest, expected);
         ASSERT_EQ(charsWritten, strlen(expected) + 1);
@@ -2026,7 +2016,7 @@ TEST(UriSuite, TestQueryCompositionMathWriteGoogleAutofuzz113244572) {
         char dest[charsRequired + 1 - 1];
         int charsWritten;
         ASSERT_TRUE(uriComposeQueryExA(dest, &first, sizeof(dest), &charsWritten,
-                                       spaceToPlus, normalizeBreaks)
+                            spaceToPlus, normalizeBreaks)
                     == URI_ERROR_OUTPUT_TOO_LARGE);
     }
 }
@@ -2109,9 +2099,9 @@ TEST(UriSuite, TestEqualsAbsolutePathWithSchemeWithHost) {
     UriUriA uriAbsPathFalse;
 
     ASSERT_EQ(uriParseSingleUriA(&uriAbsPathTrue, "scheme://host/path1", NULL),
-              URI_SUCCESS);
+            URI_SUCCESS);
     ASSERT_EQ(uriParseSingleUriA(&uriAbsPathFalse, "scheme://host/path1", NULL),
-              URI_SUCCESS);
+            URI_SUCCESS);
     uriAbsPathTrue.absolutePath = URI_TRUE;  // i.e. produce artificially
 
     EXPECT_EQ(uriAbsPathTrue.absolutePath, URI_TRUE);  // self-test
@@ -2235,8 +2225,8 @@ TEST(UriSuite, TestHostTextTerminationIssue15) {
 }
 
 namespace {
-void testRangeEqualsHelper(const char * a, const char * b, bool expected,
-                           bool avoidNullRange = true) {
+void testRangeEqualsHelper(
+        const char * a, const char * b, bool expected, bool avoidNullRange = true) {
     UriTextRangeA ra;
     UriTextRangeA rb;
 
@@ -2257,10 +2247,10 @@ void testRangeEqualsHelper(const char * a, const char * b, bool expected,
     }
 
     const bool received = uriRangeEqualsA(((a == NULL) && avoidNullRange) ? NULL : &ra,
-                                          ((b == NULL) && avoidNullRange) ? NULL : &rb);
+            ((b == NULL) && avoidNullRange) ? NULL : &rb);
     if (received != expected) {
         printf("Comparing <%s> to <%s> yields %d, expected %d.\n", a, b, (int)received,
-               (int)expected);
+                (int)expected);
     }
     ASSERT_EQ(received, expected);
 }
@@ -2293,8 +2283,8 @@ TEST(UriSuite, TestRangeComparison) {
 }
 
 namespace {
-void testRemoveBaseUriHelper(const char * expected, const char * absSourceStr,
-                             const char * absBaseStr) {
+void testRemoveBaseUriHelper(
+        const char * expected, const char * absSourceStr, const char * absBaseStr) {
     UriParserStateA state;
     UriUriA absSource;
     UriUriA absBase;
@@ -2324,34 +2314,34 @@ void testRemoveBaseUriHelper(const char * expected, const char * absSourceStr,
 
 TEST(UriSuite, TestRangeComparisonRemoveBaseUriIssue19) {
     // scheme
-    testRemoveBaseUriHelper("scheme://host/source", "scheme://host/source",
-                            "schemelonger://host/base");
+    testRemoveBaseUriHelper(
+            "scheme://host/source", "scheme://host/source", "schemelonger://host/base");
     testRemoveBaseUriHelper("schemelonger://host/source", "schemelonger://host/source",
-                            "scheme://host/base");
+            "scheme://host/base");
 
     // hostText
-    testRemoveBaseUriHelper("//host/source", "http://host/source",
-                            "http://hostlonger/base");
-    testRemoveBaseUriHelper("//hostlonger/source", "http://hostlonger/source",
-                            "http://host/base");
+    testRemoveBaseUriHelper(
+            "//host/source", "http://host/source", "http://hostlonger/base");
+    testRemoveBaseUriHelper(
+            "//hostlonger/source", "http://hostlonger/source", "http://host/base");
 
     // hostData.ipFuture
     testRemoveBaseUriHelper("//[v7.host]/source", "http://[v7.host]/source",
-                            "http://[v7.hostlonger]/base");
+            "http://[v7.hostlonger]/base");
     testRemoveBaseUriHelper("//[v7.hostlonger]/source", "http://[v7.hostlonger]/source",
-                            "http://host/base");
+            "http://host/base");
 
     // path
     testRemoveBaseUriHelper("path1", "http://host/path1", "http://host/path111");
-    testRemoveBaseUriHelper("../path1/path2", "http://host/path1/path2",
-                            "http://host/path111/path222");
+    testRemoveBaseUriHelper(
+            "../path1/path2", "http://host/path1/path2", "http://host/path111/path222");
     testRemoveBaseUriHelper("path111", "http://host/path111", "http://host/path1");
     testRemoveBaseUriHelper("../path111/path222", "http://host/path111/path222",
-                            "http://host/path1/path2");
+            "http://host/path1/path2");
 
     // Exact issue #19
-    testRemoveBaseUriHelper("//example/x/abc", "http://example/x/abc",
-                            "http://example2/x/y/z");
+    testRemoveBaseUriHelper(
+            "//example/x/abc", "http://example/x/abc", "http://example2/x/y/z");
 }
 
 TEST(ErrorPosSuite, TestErrorPosIPvFuture) {
@@ -2402,9 +2392,9 @@ TEST(UriParseSingleSuite, ErrorNullMemoryManagerDetected) {
     const char * errorPos;
     const char * const uriString = "somethingwellformed";
 
-    EXPECT_EQ(uriParseSingleUriExMmA(&uri, uriString, uriString + strlen(uriString),
-                                     &errorPos, NULL),
-              URI_SUCCESS);
+    EXPECT_EQ(uriParseSingleUriExMmA(
+                      &uri, uriString, uriString + strlen(uriString), &errorPos, NULL),
+            URI_SUCCESS);
 
     EXPECT_EQ(uriFreeUriMembersMmA(&uri, NULL), URI_SUCCESS);
 }
@@ -2569,8 +2559,8 @@ TEST(MakeOwnerSuite, MakeOwnerCopiesHostTextFuture) {  // issue #121
 TEST(ParseIpFourAddressSuite, FourSaneOctets) {
     unsigned char octetOutput[4];
     const char * const ipAddressText = "111.22.3.40";
-    const int res = uriParseIpFourAddressA(octetOutput, ipAddressText,
-                                           ipAddressText + strlen(ipAddressText));
+    const int res = uriParseIpFourAddressA(
+            octetOutput, ipAddressText, ipAddressText + strlen(ipAddressText));
     EXPECT_EQ(res, URI_SUCCESS);
     EXPECT_EQ(octetOutput[0], 111);
     EXPECT_EQ(octetOutput[1], 22);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -319,21 +319,21 @@ TEST(UriSuite, TestUri) {
     stateW.uri = &uriW;
 
     // On/off for each
-    ASSERT_EQ(
-        0, uriParseUriA(&stateA, "//user:pass@[::1]:80/segment/index.html?query#frag"));
+    ASSERT_EQ(0, uriParseUriA(&stateA,
+                              "//user:pass@[::1]:80/segment/index.html?query#frag"));
     uriFreeUriMembersA(&uriA);
     ASSERT_EQ(0, uriParseUriA(&stateA, "http://[::1]:80/segment/index.html?query#frag"));
     uriFreeUriMembersA(&uriA);
-    ASSERT_EQ(
-        0, uriParseUriA(&stateA, "http://user:pass@[::1]/segment/index.html?query#frag"));
+    ASSERT_EQ(0, uriParseUriA(&stateA,
+                              "http://user:pass@[::1]/segment/index.html?query#frag"));
     uriFreeUriMembersA(&uriA);
     ASSERT_EQ(0, uriParseUriA(&stateA, "http://user:pass@[::1]:80?query#frag"));
     uriFreeUriMembersA(&uriA);
     ASSERT_EQ(0,
               uriParseUriA(&stateA, "http://user:pass@[::1]:80/segment/index.html#frag"));
     uriFreeUriMembersA(&uriA);
-    ASSERT_EQ(
-        0, uriParseUriA(&stateA, "http://user:pass@[::1]:80/segment/index.html?query"));
+    ASSERT_EQ(0, uriParseUriA(&stateA,
+                              "http://user:pass@[::1]:80/segment/index.html?query"));
     uriFreeUriMembersA(&uriA);
 
     // Schema, port, one segment
@@ -359,10 +359,8 @@ TEST(UriSuite, TestUri) {
     // Real life examples
     ASSERT_EQ(0, uriParseUriA(&stateA, "http://sourceforge.net/projects/uriparser/"));
     uriFreeUriMembersA(&uriA);
-    ASSERT_EQ(0,
-              uriParseUriA(
-                  &stateA,
-                  "http://sourceforge.net/project/platformdownload.php?group_id=182840"));
+    ASSERT_EQ(0, uriParseUriA(&stateA, "http://sourceforge.net/project/"
+                                       "platformdownload.php?group_id=182840"));
     uriFreeUriMembersA(&uriA);
     ASSERT_EQ(0, uriParseUriA(&stateA, "mailto:test@example.com"));
     uriFreeUriMembersA(&uriA);
@@ -937,24 +935,24 @@ TEST(UriSuite, TestEscaping) {
     ASSERT_TRUE(testEscapingHelper(L"g\x0d\x0a", L"g%0D%0A", SPACE_TO_PLUS, NORMALIZE));
     ASSERT_TRUE(testEscapingHelper(L"\x0d\x0ag", L"%0D%0Ag", SPACE_TO_PLUS, NORMALIZE));
     ASSERT_TRUE(
-        testEscapingHelper(L"\x0d\x0a", L"%0D%0A", SPACE_TO_PLUS, KEEP_UNMODIFIED));
+            testEscapingHelper(L"\x0d\x0a", L"%0D%0A", SPACE_TO_PLUS, KEEP_UNMODIFIED));
     ASSERT_TRUE(
-        testEscapingHelper(L"g\x0d\x0a", L"g%0D%0A", SPACE_TO_PLUS, KEEP_UNMODIFIED));
+            testEscapingHelper(L"g\x0d\x0a", L"g%0D%0A", SPACE_TO_PLUS, KEEP_UNMODIFIED));
     ASSERT_TRUE(
-        testEscapingHelper(L"\x0d\x0ag", L"%0D%0Ag", SPACE_TO_PLUS, KEEP_UNMODIFIED));
+            testEscapingHelper(L"\x0d\x0ag", L"%0D%0Ag", SPACE_TO_PLUS, KEEP_UNMODIFIED));
 
     ASSERT_TRUE(
-        testEscapingHelper(L"\x0a\x0d", L"%0D%0A%0D%0A", SPACE_TO_PLUS, NORMALIZE));
+            testEscapingHelper(L"\x0a\x0d", L"%0D%0A%0D%0A", SPACE_TO_PLUS, NORMALIZE));
     ASSERT_TRUE(
-        testEscapingHelper(L"g\x0a\x0d", L"g%0D%0A%0D%0A", SPACE_TO_PLUS, NORMALIZE));
+            testEscapingHelper(L"g\x0a\x0d", L"g%0D%0A%0D%0A", SPACE_TO_PLUS, NORMALIZE));
     ASSERT_TRUE(
-        testEscapingHelper(L"\x0a\x0dg", L"%0D%0A%0D%0Ag", SPACE_TO_PLUS, NORMALIZE));
+            testEscapingHelper(L"\x0a\x0dg", L"%0D%0A%0D%0Ag", SPACE_TO_PLUS, NORMALIZE));
     ASSERT_TRUE(
-        testEscapingHelper(L"\x0a\x0d", L"%0A%0D", SPACE_TO_PLUS, KEEP_UNMODIFIED));
+            testEscapingHelper(L"\x0a\x0d", L"%0A%0D", SPACE_TO_PLUS, KEEP_UNMODIFIED));
     ASSERT_TRUE(
-        testEscapingHelper(L"g\x0a\x0d", L"g%0A%0D", SPACE_TO_PLUS, KEEP_UNMODIFIED));
+            testEscapingHelper(L"g\x0a\x0d", L"g%0A%0D", SPACE_TO_PLUS, KEEP_UNMODIFIED));
     ASSERT_TRUE(
-        testEscapingHelper(L"\x0a\x0dg", L"%0A%0Dg", SPACE_TO_PLUS, KEEP_UNMODIFIED));
+            testEscapingHelper(L"\x0a\x0dg", L"%0A%0Dg", SPACE_TO_PLUS, KEEP_UNMODIFIED));
 }
 
 namespace {
@@ -964,9 +962,9 @@ bool testUnescapingHelper(const wchar_t * input, const wchar_t * output,
     wchar_t * working = new wchar_t[URI_STRLEN(input) + 1];
     wcscpy(working, input);
     const wchar_t * newTermZero = uriUnescapeInPlaceExW(
-        working, plusToSpace ? URI_TRUE : URI_FALSE, breakConversion);
+            working, plusToSpace ? URI_TRUE : URI_FALSE, breakConversion);
     const bool success =
-        ((newTermZero == working + wcslen(output)) && !wcscmp(working, output));
+            ((newTermZero == working + wcslen(output)) && !wcscmp(working, output));
     delete[] working;
     return success;
 }
@@ -996,60 +994,60 @@ TEST(UriSuite, TestUnescaping) {
 
     // Line break conversion
     ASSERT_TRUE(testUnescapingHelper(L"%0d", L"\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0d", L"\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(L"%0d", L"\x0d\x0a", PLUS_DONT_TOUCH,
+                                     URI_BR_TO_WINDOWS));
     ASSERT_TRUE(testUnescapingHelper(L"%0d", L"\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
     ASSERT_TRUE(
-        testUnescapingHelper(L"%0d", L"\x0d", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
+            testUnescapingHelper(L"%0d", L"\x0d", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0d%0d", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(L"%0d%0d", L"\x0a\x0a", PLUS_DONT_TOUCH,
+                                     URI_BR_TO_UNIX));
     ASSERT_TRUE(testUnescapingHelper(L"%0d%0d", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH,
                                      URI_BR_TO_WINDOWS));
     ASSERT_TRUE(
-        testUnescapingHelper(L"%0d%0d", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0d%0d", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
+            testUnescapingHelper(L"%0d%0d", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
+    ASSERT_TRUE(testUnescapingHelper(L"%0d%0d", L"\x0d\x0d", PLUS_DONT_TOUCH,
+                                     URI_BR_DONT_TOUCH));
 
     ASSERT_TRUE(testUnescapingHelper(L"%0a", L"\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0a", L"\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(L"%0a", L"\x0d\x0a", PLUS_DONT_TOUCH,
+                                     URI_BR_TO_WINDOWS));
     ASSERT_TRUE(testUnescapingHelper(L"%0a", L"\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
     ASSERT_TRUE(
-        testUnescapingHelper(L"%0a", L"\x0a", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
+            testUnescapingHelper(L"%0a", L"\x0a", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0a%0a", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(L"%0a%0a", L"\x0a\x0a", PLUS_DONT_TOUCH,
+                                     URI_BR_TO_UNIX));
     ASSERT_TRUE(testUnescapingHelper(L"%0a%0a", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH,
                                      URI_BR_TO_WINDOWS));
     ASSERT_TRUE(
-        testUnescapingHelper(L"%0a%0a", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0a%0a", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
-
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0d%0a", L"\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0d%0a", L"\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_TO_WINDOWS));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a", L"\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0d%0a", L"\x0d\x0a", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
-
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0d%0a%0a", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0a", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH,
-                                     URI_BR_TO_WINDOWS));
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0d%0a%0a", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
-    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0a", L"\x0d\x0a\x0a", PLUS_DONT_TOUCH,
+            testUnescapingHelper(L"%0a%0a", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
+    ASSERT_TRUE(testUnescapingHelper(L"%0a%0a", L"\x0a\x0a", PLUS_DONT_TOUCH,
                                      URI_BR_DONT_TOUCH));
 
     ASSERT_TRUE(
-        testUnescapingHelper(L"%0d%0a%0d", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
+            testUnescapingHelper(L"%0d%0a", L"\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a", L"\x0d\x0a", PLUS_DONT_TOUCH,
+                                     URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a", L"\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
+    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a", L"\x0d\x0a", PLUS_DONT_TOUCH,
+                                     URI_BR_DONT_TOUCH));
+
+    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0a", L"\x0a\x0a", PLUS_DONT_TOUCH,
+                                     URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0a", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH,
+                                     URI_BR_TO_WINDOWS));
+    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0a", L"\x0d\x0d", PLUS_DONT_TOUCH,
+                                     URI_BR_TO_MAC));
+    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0a", L"\x0d\x0a\x0a", PLUS_DONT_TOUCH,
+                                     URI_BR_DONT_TOUCH));
+
+    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0d", L"\x0a\x0a", PLUS_DONT_TOUCH,
+                                     URI_BR_TO_UNIX));
     ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0d", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH,
                                      URI_BR_TO_WINDOWS));
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0d%0a%0d", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
+    ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0d", L"\x0d\x0d", PLUS_DONT_TOUCH,
+                                     URI_BR_TO_MAC));
     ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0d", L"\x0d\x0a\x0d", PLUS_DONT_TOUCH,
                                      URI_BR_DONT_TOUCH));
 
@@ -1062,21 +1060,21 @@ TEST(UriSuite, TestUnescaping) {
     ASSERT_TRUE(testUnescapingHelper(L"%0d%0a%0d%0a", L"\x0d\x0a\x0d\x0a",
                                      PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
 
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0a%0d", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d", L"\x0a\x0a", PLUS_DONT_TOUCH,
+                                     URI_BR_TO_UNIX));
     ASSERT_TRUE(testUnescapingHelper(L"%0a%0d", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH,
                                      URI_BR_TO_WINDOWS));
     ASSERT_TRUE(
-        testUnescapingHelper(L"%0a%0d", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0a%0d", L"\x0a\x0d", PLUS_DONT_TOUCH, URI_BR_DONT_TOUCH));
+            testUnescapingHelper(L"%0a%0d", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
+    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d", L"\x0a\x0d", PLUS_DONT_TOUCH,
+                                     URI_BR_DONT_TOUCH));
 
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0a%0d%0a", L"\x0a\x0a", PLUS_DONT_TOUCH, URI_BR_TO_UNIX));
+    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0a", L"\x0a\x0a", PLUS_DONT_TOUCH,
+                                     URI_BR_TO_UNIX));
     ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0a", L"\x0d\x0a\x0d\x0a", PLUS_DONT_TOUCH,
                                      URI_BR_TO_WINDOWS));
-    ASSERT_TRUE(
-        testUnescapingHelper(L"%0a%0d%0a", L"\x0d\x0d", PLUS_DONT_TOUCH, URI_BR_TO_MAC));
+    ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0a", L"\x0d\x0d", PLUS_DONT_TOUCH,
+                                     URI_BR_TO_MAC));
     ASSERT_TRUE(testUnescapingHelper(L"%0a%0d%0a", L"\x0a\x0d\x0a", PLUS_DONT_TOUCH,
                                      URI_BR_DONT_TOUCH));
 
@@ -1203,11 +1201,11 @@ TEST(UriSuite, TestAddBase) {
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"#s", L"http://a/b/c/d;p?q#s"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g#s", L"http://a/b/c/g#s"));
     ASSERT_TRUE(
-        testAddBaseHelper(L"http://a/b/c/d;p?q", L"g?y#s", L"http://a/b/c/g?y#s"));
+            testAddBaseHelper(L"http://a/b/c/d;p?q", L"g?y#s", L"http://a/b/c/g?y#s"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L";x", L"http://a/b/c/;x"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g;x", L"http://a/b/c/g;x"));
-    ASSERT_TRUE(
-        testAddBaseHelper(L"http://a/b/c/d;p?q", L"g;x?y#s", L"http://a/b/c/g;x?y#s"));
+    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g;x?y#s",
+                                  L"http://a/b/c/g;x?y#s"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"", L"http://a/b/c/d;p?q"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L".", L"http://a/b/c/"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"./", L"http://a/b/c/"));
@@ -1221,7 +1219,7 @@ TEST(UriSuite, TestAddBase) {
     // 5.4.2. Abnormal Examples
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"../../../g", L"http://a/g"));
     ASSERT_TRUE(
-        testAddBaseHelper(L"http://a/b/c/d;p?q", L"../../../../g", L"http://a/g"));
+            testAddBaseHelper(L"http://a/b/c/d;p?q", L"../../../../g", L"http://a/g"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"/./g", L"http://a/g"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"/../g", L"http://a/g"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g.", L"http://a/b/c/g."));
@@ -1232,28 +1230,28 @@ TEST(UriSuite, TestAddBase) {
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"./g/.", L"http://a/b/c/g/"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g/./h", L"http://a/b/c/g/h"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g/../h", L"http://a/b/c/h"));
+    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g;x=1/./y",
+                                  L"http://a/b/c/g;x=1/y"));
     ASSERT_TRUE(
-        testAddBaseHelper(L"http://a/b/c/d;p?q", L"g;x=1/./y", L"http://a/b/c/g;x=1/y"));
-    ASSERT_TRUE(
-        testAddBaseHelper(L"http://a/b/c/d;p?q", L"g;x=1/../y", L"http://a/b/c/y"));
-    ASSERT_TRUE(
-        testAddBaseHelper(L"http://a/b/c/d;p?q", L"g?y/./x", L"http://a/b/c/g?y/./x"));
-    ASSERT_TRUE(
-        testAddBaseHelper(L"http://a/b/c/d;p?q", L"g?y/../x", L"http://a/b/c/g?y/../x"));
-    ASSERT_TRUE(
-        testAddBaseHelper(L"http://a/b/c/d;p?q", L"g#s/./x", L"http://a/b/c/g#s/./x"));
-    ASSERT_TRUE(
-        testAddBaseHelper(L"http://a/b/c/d;p?q", L"g#s/../x", L"http://a/b/c/g#s/../x"));
+            testAddBaseHelper(L"http://a/b/c/d;p?q", L"g;x=1/../y", L"http://a/b/c/y"));
+    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g?y/./x",
+                                  L"http://a/b/c/g?y/./x"));
+    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g?y/../x",
+                                  L"http://a/b/c/g?y/../x"));
+    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g#s/./x",
+                                  L"http://a/b/c/g#s/./x"));
+    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"g#s/../x",
+                                  L"http://a/b/c/g#s/../x"));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"http:g", L"http:g"));
 
     // Backward compatibility (feature request #4, RFC3986 5.4.2)
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"http:g", L"http:g", false));
     ASSERT_TRUE(
-        testAddBaseHelper(L"http://a/b/c/d;p?q", L"http:g", L"http://a/b/c/g", true));
+            testAddBaseHelper(L"http://a/b/c/d;p?q", L"http:g", L"http://a/b/c/g", true));
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"http:g?q#f",
                                   L"http://a/b/c/g?q#f", true));
-    ASSERT_TRUE(
-        testAddBaseHelper(L"http://a/b/c/d;p?q", L"other:g?q#f", L"other:g?q#f", true));
+    ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"other:g?q#f", L"other:g?q#f",
+                                  true));
 
     // Bug related to absolutePath flag set despite presence of host
     ASSERT_TRUE(testAddBaseHelper(L"http://a/b/c/d;p?q", L"/", L"http://a/"));
@@ -1500,12 +1498,12 @@ TEST(UriSuite, TestNormalizeSyntaxMaskRequired) {
     ASSERT_TRUE(testNormalizeMaskHelper(L"http://localhost/", URI_NORMALIZED));
     ASSERT_TRUE(testNormalizeMaskHelper(L"httP://localhost/", URI_NORMALIZE_SCHEME));
     ASSERT_TRUE(
-        testNormalizeMaskHelper(L"http://%0d@localhost/", URI_NORMALIZE_USER_INFO));
+            testNormalizeMaskHelper(L"http://%0d@localhost/", URI_NORMALIZE_USER_INFO));
     ASSERT_TRUE(testNormalizeMaskHelper(L"http://localhosT/", URI_NORMALIZE_HOST));
     ASSERT_TRUE(testNormalizeMaskHelper(L"http://localhost/./abc", URI_NORMALIZE_PATH));
     ASSERT_TRUE(testNormalizeMaskHelper(L"http://localhost/?AB%43", URI_NORMALIZE_QUERY));
     ASSERT_TRUE(
-        testNormalizeMaskHelper(L"http://localhost/#AB%43", URI_NORMALIZE_FRAGMENT));
+            testNormalizeMaskHelper(L"http://localhost/#AB%43", URI_NORMALIZE_FRAGMENT));
 }
 
 TEST(UriSuite, TestNormalizeSyntaxMaskRequiredPort) {
@@ -1575,7 +1573,7 @@ TEST(UriSuite, TestNormalizeSyntax) {
 
     // Testcase by Adrian Manrique
     ASSERT_TRUE(
-        testNormalizeSyntaxHelper(L"http://examp%4Ce.com/", L"http://example.com/"));
+            testNormalizeSyntaxHelper(L"http://examp%4Ce.com/", L"http://example.com/"));
 
     // Testcase by Adrian Manrique
     ASSERT_TRUE(testNormalizeSyntaxHelper(L"http://example.com/a/b/%2E%2E/",
@@ -1585,9 +1583,9 @@ TEST(UriSuite, TestNormalizeSyntax) {
     ASSERT_TRUE(testNormalizeSyntaxHelper(L"http://user:pass@SOMEHOST.COM:123",
                                           L"http://user:pass@somehost.com:123"));
 
-    ASSERT_TRUE(
-        testNormalizeSyntaxHelper(L"https://%e4%bd%a0%e5%a5%bd%e4%bd%a0%e5%a5%bd.com",
-                                  L"https://%E4%BD%A0%E5%A5%BD%E4%BD%A0%E5%A5%BD.com"));
+    ASSERT_TRUE(testNormalizeSyntaxHelper(
+            L"https://%e4%bd%a0%e5%a5%bd%e4%bd%a0%e5%a5%bd.com",
+            L"https://%E4%BD%A0%E5%A5%BD%E4%BD%A0%E5%A5%BD.com"));
 
     ASSERT_TRUE(testNormalizeSyntaxHelper(L"https://[2041:0000:140F::875B:131B]",
                                           L"https://[2041:0000:140f::875b:131b]"));
@@ -1669,10 +1667,10 @@ TEST(UriSuite, TestNormalizeSyntaxPath) {
 
     // .. and these are related
     EXPECT_TRUE(
-        testNormalizeSyntaxHelper(L"http://a/..", L"http://a/", URI_NORMALIZE_PATH));
+            testNormalizeSyntaxHelper(L"http://a/..", L"http://a/", URI_NORMALIZE_PATH));
     EXPECT_TRUE(testNormalizeSyntaxHelper(L"/..", L"/", URI_NORMALIZE_PATH));
-    EXPECT_TRUE(
-        testNormalizeSyntaxHelper(L"http://a/..///", L"http://a///", URI_NORMALIZE_PATH));
+    EXPECT_TRUE(testNormalizeSyntaxHelper(L"http://a/..///", L"http://a///",
+                                          URI_NORMALIZE_PATH));
     EXPECT_TRUE(testNormalizeSyntaxHelper(L"http://a/..///..", L"http://a//",
                                           URI_NORMALIZE_PATH));
     EXPECT_TRUE(testNormalizeSyntaxHelper(L"a/b/c/../../..", L"", URI_NORMALIZE_PATH));
@@ -1704,10 +1702,10 @@ TEST(UriSuite, TestNormalizeCrashBug20080224) {
 TEST(UriSuite, TestNormalizeBug262Fixed) {
     EXPECT_TRUE(testNormalizeSyntaxHelper(L"scheme:/.//foo/bar", L"scheme:/.//foo/bar",
                                           URI_NORMALIZE_PATH));
+    EXPECT_TRUE(testNormalizeSyntaxHelper(L"/.//foo/bar", L"/.//foo/bar",
+                                          URI_NORMALIZE_PATH));
     EXPECT_TRUE(
-        testNormalizeSyntaxHelper(L"/.//foo/bar", L"/.//foo/bar", URI_NORMALIZE_PATH));
-    EXPECT_TRUE(
-        testNormalizeSyntaxHelper(L".//foo/bar", L".//foo/bar", URI_NORMALIZE_PATH));
+            testNormalizeSyntaxHelper(L".//foo/bar", L".//foo/bar", URI_NORMALIZE_PATH));
 }
 
 TEST(UriSuite, TestNormalizeBug262Unchanged) {
@@ -1716,7 +1714,7 @@ TEST(UriSuite, TestNormalizeBug262Unchanged) {
     EXPECT_TRUE(testNormalizeSyntaxHelper(L"scheme:/./foo/bar", L"scheme:/foo/bar",
                                           URI_NORMALIZE_PATH));
     EXPECT_TRUE(
-        testNormalizeSyntaxHelper(L"/./foo/bar", L"/foo/bar", URI_NORMALIZE_PATH));
+            testNormalizeSyntaxHelper(L"/./foo/bar", L"/foo/bar", URI_NORMALIZE_PATH));
     EXPECT_TRUE(testNormalizeSyntaxHelper(L"./foo/bar", L"foo/bar", URI_NORMALIZE_PATH));
 
     // 2x same as TestNormalizeBug262Fixed above
@@ -1997,7 +1995,7 @@ TEST(UriSuite, TestQueryCompositionMathCalc) {
     const int FACTOR = 6; /* due to escaping with normalizeBreaks */
     ASSERT_EQ((unsigned)charsRequired,
               FACTOR * strlen(first.key) + 1 + FACTOR * strlen(first.value) + 1
-                  + FACTOR * strlen(second.key) + 1 + FACTOR * strlen(second.value));
+                      + FACTOR * strlen(second.key) + 1 + FACTOR * strlen(second.value));
 }
 
 TEST(UriSuite, TestQueryCompositionMathWriteGoogleAutofuzz113244572) {
@@ -2474,7 +2472,7 @@ TEST(FreeUriMembersSuite, FreeUriMembersFreesHostTextFuture) {  // issue #121
 
 TEST(MakeOwnerSuite, MakeOwner) {
     const char * const uriString =
-        "scheme://user:pass@[v7.X]:55555/path/../path/?query#fragment";
+            "scheme://user:pass@[v7.X]:55555/path/../path/?query#fragment";
     UriUriA uri;
     char * uriFirst = strdup(uriString);
     const size_t uriLen = strlen(uriFirst);

--- a/tool/uriparse.c
+++ b/tool/uriparse.c
@@ -45,8 +45,8 @@
 #  include <winsock2.h>
 #  include <ws2tcpip.h>
 #  if defined(__MINGW32__) \
-      && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 3 \
-          || _WIN32_WINNT < _WIN32_WINNT_VISTA)
+          && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 3 \
+              || _WIN32_WINNT < _WIN32_WINNT_VISTA)
 WINSOCK_API_LINKAGE const char * WSAAPI inet_ntop(int af, const void * src, char * dst,
                                                   size_t size);
 #  endif
@@ -69,9 +69,9 @@ void dumpRange(const char * label, const UriTextRangeA * range) {
     const size_t labelLenChars = strlen(label);
 
     const int gapLenChars =
-        (leftColumnMinWidthChars - /* the colon */ 1 > labelLenChars)
-            ? (int)(leftColumnMinWidthChars - labelLenChars - /* the colon */ 1)
-            : /* minimum gap */ 1;
+            (leftColumnMinWidthChars - /* the colon */ 1 > labelLenChars)
+                    ? (int)(leftColumnMinWidthChars - labelLenChars - /* the colon */ 1)
+                    : /* minimum gap */ 1;
 
     fprintf(stdout, "%s:%*s", label, gapLenChars, "");
     fwrite(range->first, range->afterLast - range->first, 1, stdout);
@@ -99,8 +99,8 @@ int main(int argc, char * argv[]) {
             printf("Failure:      %s @ '%.18s' (#%lu)\n",
                    (state.errorCode == URI_ERROR_SYNTAX) ? "syntax"
                    : (state.errorCode == URI_ERROR_MALLOC)
-                       ? "not enough memory"
-                       : "liburiparser bug (please report)",
+                           ? "not enough memory"
+                           : "liburiparser bug (please report)",
                    state.errorPos, (long unsigned int)(state.errorPos - argv[i]));
             retval = EXIT_FAILURE;
         } else {

--- a/tool/uriparse.c
+++ b/tool/uriparse.c
@@ -46,9 +46,9 @@
 #  include <ws2tcpip.h>
 #  if defined(__MINGW32__) \
           && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 3 \
-              || _WIN32_WINNT < _WIN32_WINNT_VISTA)
-WINSOCK_API_LINKAGE const char * WSAAPI inet_ntop(int af, const void * src, char * dst,
-                                                  size_t size);
+                  || _WIN32_WINNT < _WIN32_WINNT_VISTA)
+WINSOCK_API_LINKAGE const char * WSAAPI inet_ntop(
+        int af, const void * src, char * dst, size_t size);
 #  endif
 #else
 #  include <sys/socket.h>
@@ -97,11 +97,11 @@ int main(int argc, char * argv[]) {
         if (uriParseUriA(&state, argv[i]) != URI_SUCCESS) {
             /* Failure */
             printf("Failure:      %s @ '%.18s' (#%lu)\n",
-                   (state.errorCode == URI_ERROR_SYNTAX) ? "syntax"
-                   : (state.errorCode == URI_ERROR_MALLOC)
-                           ? "not enough memory"
-                           : "liburiparser bug (please report)",
-                   state.errorPos, (long unsigned int)(state.errorPos - argv[i]));
+                    (state.errorCode == URI_ERROR_SYNTAX) ? "syntax"
+                    : (state.errorCode == URI_ERROR_MALLOC)
+                            ? "not enough memory"
+                            : "liburiparser bug (please report)",
+                    state.errorPos, (long unsigned int)(state.errorPos - argv[i]));
             retval = EXIT_FAILURE;
         } else {
             if (uri.scheme.first) {
@@ -141,10 +141,10 @@ int main(int argc, char * argv[]) {
             }
             const char * const absolutePathLabel = "absolutePath: ";
             printf("%s%s\n", absolutePathLabel,
-                   (uri.absolutePath == URI_TRUE) ? "true" : "false");
+                    (uri.absolutePath == URI_TRUE) ? "true" : "false");
             if (uri.hostText.first != NULL) {
                 printf("%*s%s\n", (int)strlen(absolutePathLabel), "",
-                       "(always false for URIs with host)");
+                        "(always false for URIs with host)");
             }
         }
         printf("\n");


### PR DESCRIPTION
### Before
```c
if (one
    && two
    && three) {
    body
}
```

### After
```c
if (one
        && two
        && three) {
    body
}
```