### PR TITLE
CMake: Allow CXX_STANDARD version to be settable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,9 +93,9 @@ if(URIPARSER_BUILD_TESTS OR URIPARSER_BUILD_FUZZERS)
     enable_language(CXX)
 
     if(URIPARSER_BUILD_FUZZERS)
-        set(CMAKE_CXX_STANDARD 17)
+        set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ Standard to use")
     else()
-        set(CMAKE_CXX_STANDARD 11)
+        set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ Standard to use")
     endif()
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
     set(CMAKE_CXX_EXTENSIONS OFF)  # i.e. -std=c++11 rather than default -std=gnu++11


### PR DESCRIPTION
When trying to compile with newer GTest, it requires C++17 to be minimum. But since the C++ standard version is hardcoded, it's not possible to override it via -D.

If we use set with CACHE instead, the -DCMAKE_CXX_STANDARD=17 allows the version to be set when running cmake that is not overriden.