### PR TITLE
Fix support for GoogleTest >=1.17.0 / Make CI cover (both less and) more recent GoogleTest (alternative to #324)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,24 +24,28 @@ jobs:
           - runs-on: windows-2022
             cmake_generator: Visual Studio 17 2022
             common_cmake_args: -A Win32
+            googletest_version: 1.12.0
             uriparser_sln: uriparser.sln
 
           # Visual Studio 2022, 64 bit
           - runs-on: windows-2022
             cmake_generator: Visual Studio 17 2022
             common_cmake_args: -A x64
+            googletest_version: 1.12.0
             uriparser_sln: uriparser.sln
 
           # Visual Studio 2026, 32 bit
           - runs-on: windows-2025-vs2026
             cmake_generator: Visual Studio 18 2026
             common_cmake_args: -A Win32
+            googletest_version: 1.12.0
             uriparser_sln: uriparser.slnx
 
           # Visual Studio 2026, 64 bit
           - runs-on: windows-2025-vs2026
             cmake_generator: Visual Studio 18 2026
             common_cmake_args: -A x64
+            googletest_version: 1.12.0
             uriparser_sln: uriparser.slnx
 
     runs-on: ${{ matrix.runs-on }}
@@ -51,7 +55,7 @@ jobs:
     env:
       CMAKE_GENERATOR: ${{ matrix.cmake_generator }}
       COMMON_CMAKE_ARGS: ${{ matrix.common_cmake_args }}
-      GTEST_VERSION: 1.12.0
+      GTEST_VERSION: ${{ matrix.googletest_version }}
     steps:
 
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,21 +31,21 @@ jobs:
           - runs-on: windows-2022
             cmake_generator: Visual Studio 17 2022
             common_cmake_args: -A x64
-            googletest_version: 1.12.0
+            googletest_version: 1.14.0  # matches Ubuntu 24.04
             uriparser_sln: uriparser.sln
 
           # Visual Studio 2026, 32 bit
           - runs-on: windows-2025-vs2026
             cmake_generator: Visual Studio 18 2026
             common_cmake_args: -A Win32
-            googletest_version: 1.12.0
+            googletest_version: 1.16.0  # matches Debian trixie
             uriparser_sln: uriparser.slnx
 
           # Visual Studio 2026, 64 bit
           - runs-on: windows-2025-vs2026
             cmake_generator: Visual Studio 18 2026
             common_cmake_args: -A x64
-            googletest_version: 1.12.0
+            googletest_version: 1.17.0  # latest upstream with C++17
             uriparser_sln: uriparser.slnx
 
     runs-on: ${{ matrix.runs-on }}
@@ -69,6 +69,15 @@ jobs:
         unzip -q "release-${GTEST_VERSION}.zip"
 
         cd "googletest-${GTEST_VERSION}"
+
+        # Workaround compilation issues with GoogleTest 1.17.0
+        # - https://github.com/google/googletest/issues/4731
+        # - https://github.com/google/googletest/pull/4877
+        if [[ ${GTEST_VERSION} = 1.17.0 ]] ; then
+          curl -fsSL -o build.patch https://github.com/google/googletest/commit/0b656495436f57212be8700794a3d5fb14000c5f.patch
+          patch -p 1 < build.patch
+        fi
+
         cmake \
           -G "${CMAKE_GENERATOR}" \
           -DCVF_VERSION="${GTEST_VERSION}" \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,10 +65,10 @@ jobs:
     - name: Build dependency googletest
       run: |-
         set -x
-        curl -fsSL -o "release-${GTEST_VERSION}.zip" "https://github.com/google/googletest/archive/release-${GTEST_VERSION}.zip"
+        curl -fsSL -o "release-${GTEST_VERSION}.zip" "https://github.com/google/googletest/archive/refs/tags/v${GTEST_VERSION}.zip"
         unzip -q "release-${GTEST_VERSION}.zip"
 
-        cd "googletest-release-${GTEST_VERSION}"
+        cd "googletest-${GTEST_VERSION}"
         cmake \
           -G "${CMAKE_GENERATOR}" \
           -DCVF_VERSION="${GTEST_VERSION}" \
@@ -84,7 +84,7 @@ jobs:
         cmake_args=(
           -G "${CMAKE_GENERATOR}"
           # NOTE: GTEST_ROOT is relative to source CMakeLists.txt, not the build directory
-          -DGTEST_ROOT="googletest-release-${GTEST_VERSION}/googletest"
+          -DGTEST_ROOT="googletest-${GTEST_VERSION}/googletest"
           -DURIPARSER_BUILD_DOCS=OFF
           -DURIPARSER_BUILD_TESTS=ON
           -DURIPARSER_MSVC_STATIC_CRT=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,9 +93,9 @@ if(URIPARSER_BUILD_TESTS OR URIPARSER_BUILD_FUZZERS)
     enable_language(CXX)
 
     if(URIPARSER_BUILD_FUZZERS)
-        set(CMAKE_CXX_STANDARD 17)
+        set(CMAKE_CXX_STANDARD 17)  # for use of Clang's fuzzer/FuzzedDataProvider.h
     else()
-        set(CMAKE_CXX_STANDARD 17)
+        set(CMAKE_CXX_STANDARD 17)  # for GoogleTest >=1.17.0
     endif()
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
     set(CMAKE_CXX_EXTENSIONS OFF)  # i.e. -std=c++11 rather than default -std=gnu++11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ if(URIPARSER_BUILD_TESTS OR URIPARSER_BUILD_FUZZERS)
     if(URIPARSER_BUILD_FUZZERS)
         set(CMAKE_CXX_STANDARD 17)
     else()
-        set(CMAKE_CXX_STANDARD 11)
+        set(CMAKE_CXX_STANDARD 17)
     endif()
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
     set(CMAKE_CXX_EXTENSIONS OFF)  # i.e. -std=c++11 rather than default -std=gnu++11


### PR DESCRIPTION
Alternative to #324

Related:
- https://github.com/google/googletest/issues/4731
- https://github.com/google/googletest/pull/4877

CC @AdamMajer @charles-lunarg