### PR TITLE
Mark `uriIsWellFormedHostIp6A()` as `URI_PUBLIC`

### DIFF
--- a/include/uriparser/Uri.h
+++ b/include/uriparser/Uri.h
@@ -1199,9 +1199,10 @@ URI_PUBLIC UriBool URI_FUNC(IsWellFormedHostIp4)(
  * @see uriIsWellFormedUserInfoA
  * @see uriParseIpSixAddressA
  * @see uriParseIpSixAddressMmA
- * @since 0.9.9
+ * @since 1.0.3
  */
-int URI_FUNC(IsWellFormedHostIp6)(const URI_CHAR * first, const URI_CHAR * afterLast);
+URI_PUBLIC int URI_FUNC(IsWellFormedHostIp6)(
+        const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
  * Determines if the given text range contains a well-formed IPv6 address


### PR DESCRIPTION
So that external versions of liburiparser can be used when building PHP

In the process, update the documented version of the function to say 1.0.3 (the version in which it will be marked as public) rather than 0.9.9 (the version in which it was introduced).

See php/php-src#22553