### PR TITLE
Mark other URI_FUNC(IsWellFormedHost*) function variants as URI_PUBLIC

### DIFF
--- a/include/uriparser/Uri.h
+++ b/include/uriparser/Uri.h
@@ -1224,9 +1224,9 @@ URI_PUBLIC int URI_FUNC(IsWellFormedHostIp6)(
  * @see uriIsWellFormedQueryA
  * @see uriIsWellFormedSchemeA
  * @see uriIsWellFormedUserInfoA
- * @since 0.9.9
+ * @since 1.0.3
  */
-int URI_FUNC(IsWellFormedHostIp6Mm)(
+URI_PUBLIC int URI_FUNC(IsWellFormedHostIp6Mm)(
         const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**
@@ -1252,9 +1252,9 @@ int URI_FUNC(IsWellFormedHostIp6Mm)(
  * @see uriIsWellFormedUserInfoA
  * @see uriSetHostIpFutureA
  * @see uriSetHostIpFutureMmA
- * @since 0.9.9
+ * @since 1.0.3
  */
-int URI_FUNC(IsWellFormedHostIpFuture)(
+URI_PUBLIC int URI_FUNC(IsWellFormedHostIpFuture)(
         const URI_CHAR * first, const URI_CHAR * afterLast);
 
 /**
@@ -1279,9 +1279,9 @@ int URI_FUNC(IsWellFormedHostIpFuture)(
  * @see uriIsWellFormedUserInfoA
  * @see uriSetHostIpFutureA
  * @see uriSetHostIpFutureMmA
- * @since 0.9.9
+ * @since 1.0.3
  */
-int URI_FUNC(IsWellFormedHostIpFutureMm)(
+URI_PUBLIC int URI_FUNC(IsWellFormedHostIpFutureMm)(
         const URI_CHAR * first, const URI_CHAR * afterLast, UriMemoryManager * memory);
 
 /**


### PR DESCRIPTION
`URI_FUNC(IsWellFormedHostIp6Mm)`, `URI_FUNC(IsWellFormedHostIpFuture)` as well as `URI_FUNC(IsWellFormedHostIpFutureMm)` are also marked with `URI_PUBLIC` to fully fix https://github.com/php/php-src/issues/22553.

The documented version of these functions is updated from 0.9.9 to 1.0.3.

This is a followup for https://github.com/uriparser/uriparser/pull/328.